### PR TITLE
feat: start reading the Reference Include property

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as _ from 'lodash';
 
 import {PkgTree, DepType, parseManifestFile,
-  getDependencyTreeFromPackagesConfig, getDependencyTreeFromPackageReference} from './parsers';
+  getDependencyTreeFromPackagesConfig, getDependencyTreeFromCsproj} from './parsers';
 
 export {
   buildDepTreeFromPackagesConfig,
@@ -30,7 +30,7 @@ async function buildDepTreeFromCsproj(
     includeDev = false): Promise<PkgTree> {
   try {
     const manifestFile: any = await parseManifestFile(manifestFileContents);
-    return getDependencyTreeFromPackageReference(manifestFile, includeDev);
+    return getDependencyTreeFromCsproj(manifestFile, includeDev);
   } catch (err) {
     throw new Error(`Building dependency tree failed with error ${err.message}`);
   }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,10 +1,5 @@
 import * as parseXML from 'xml2js';
 import * as _ from 'lodash';
-export interface Dep {
-  name: string;
-  version: string;
-  dev?: boolean;
-}
 
 export interface PkgTree {
   name: string;
@@ -20,6 +15,13 @@ export interface PkgTree {
 export enum DepType {
   prod = 'prod',
   dev = 'dev',
+}
+
+export interface ReferenceInclude {
+  Version?: string;
+  Culture?: string;
+  processorArchitecture?: string;
+  PublicKeyToken?: string;
 }
 
 export async function getDependencyTreeFromPackagesConfig(manifestFile, includeDev: boolean = false) {
@@ -56,10 +58,7 @@ function buildSubTreeFromPackagesConfig(dep, isDev: boolean): PkgTree {
   return depSubTree;
 }
 
-export async function getDependencyTreeFromPackageReference(manifestFile, includeDev: boolean = false) {
-  const packageList = _.get(manifestFile, 'Project.ItemGroup', [])
-    .find((itemGroup) => _.has(itemGroup, 'PackageReference'));
-
+export async function getDependencyTreeFromCsproj(manifestFile, includeDev: boolean = false) {
   const nameProperty = _.get(manifestFile, 'Project.PropertyGroup', [])
     .find((propertyGroup) => {
       return _.has(propertyGroup, 'PackageId')
@@ -77,6 +76,24 @@ export async function getDependencyTreeFromPackageReference(manifestFile, includ
     version: '',
   };
 
+  const packageReferenceDepTree = await getDependencyTreeFromPackageReference(manifestFile, includeDev, depTree);
+  const combinedDepTree: PkgTree = {
+    // TODO: also combine the TargetFrameworks dep tree into here
+    ...packageReferenceDepTree,
+  };
+
+  combinedDepTree.dependencies = {
+    ...combinedDepTree.dependencies,
+    ...(await getDependenciesListFromReferenceInclude(manifestFile)),
+  };
+
+  return combinedDepTree;
+}
+
+export async function getDependencyTreeFromPackageReference(manifestFile, includeDev: boolean = false, depTree) {
+  const packageList = _.get(manifestFile, 'Project.ItemGroup', [])
+    .find((itemGroup) => _.has(itemGroup, 'PackageReference'));
+
   if (!packageList) {
     return depTree;
   }
@@ -92,6 +109,39 @@ export async function getDependencyTreeFromPackageReference(manifestFile, includ
   }
 
   return depTree;
+}
+
+export async function getDependenciesListFromReferenceInclude(manifestFile) {
+  const referenceIncludeDependencies = {};
+  const referenceIncludeList = _.get(manifestFile, 'Project.ItemGroup', [])
+  .find((itemGroup) => _.has(itemGroup, 'Reference'));
+
+  if (!referenceIncludeList) {
+    return referenceIncludeDependencies;
+  }
+
+  for (const item of referenceIncludeList.Reference) {
+    const propertiesList = item.$.Include.split(',').map((i) => i.trim());
+    const [depName, ...depInfoArray] = propertiesList;
+    const depInfoRaw =
+      _.keyBy(depInfoArray, (prop) => prop.split('=')[0]);
+
+    const depInfo: ReferenceInclude = {};
+    for (const property of Object.keys(depInfoRaw)) {
+      depInfo[property] = depInfoRaw[property].split('=')[1];
+    }
+
+    const dependency: PkgTree = {
+      // TODO: correctly identify what makes the dep be dev only
+      depType: DepType.prod,
+      dependencies: {},
+      name: depName,
+      version: depInfo.Version || '',
+    };
+
+    referenceIncludeDependencies[depName] = dependency;
+  }
+  return referenceIncludeDependencies;
 }
 
 function buildSubTreeFromPackageReference(dep, isDev: boolean): PkgTree {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+      "integrity": "sha1-gaZzHOTfQ2GeXIyUU4Oz5iqJ6oY="
     },
     "@types/lodash": {
       "version": "4.14.116",
@@ -22,7 +22,7 @@
     "@types/xml2js": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
-      "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
+      "integrity": "sha1-L0G/x01aQCJRFyH4cu05WiEK07c=",
       "requires": {
         "@types/events": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "npm run lint && npm run unit-test",
-    "unit-test": "tap test/lib -R=spec --timeout=300 --node-path ts-node --test-file-pattern '/\\.[tj]s$/'",
+    "unit-test": "tap test/lib -Rspec --timeout=300 --node-path ts-node --test-file-pattern '/\\.[tj]s$/'",
     "lint": "tslint -p tsconfig.json",
     "build": "tsc",
     "build-watch": "tsc -w",

--- a/test/fixtures/dotnet-core-simple-project/expected-tree.json
+++ b/test/fixtures/dotnet-core-simple-project/expected-tree.json
@@ -1,91 +1,157 @@
 {
-  "name": "Simple-Project-Name",
-  "version": "",
-  "hasDevDependencies": false,
   "dependencies": {
     "Microsoft.AspNetCore": {
-      "name": "Microsoft.AspNetCore",
-      "version": "1.1.7",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore",
+      "version": "1.1.7"
     },
     "Microsoft.AspNetCore.Authentication.Cookies": {
-      "name": "Microsoft.AspNetCore.Authentication.Cookies",
-      "version": "1.1.3",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Authentication.Cookies",
+      "version": "1.1.3"
     },
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": {
-      "name": "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore",
-      "version":"1.1.6",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore",
+      "version": "1.1.6"
     },
     "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
-      "name": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
-      "version":"1.1.6",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
+      "version": "1.1.6"
     },
     "Microsoft.AspNetCore.Mvc": {
-      "name": "Microsoft.AspNetCore.Mvc",
-      "version":"1.1.8",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Mvc",
+      "version": "1.1.8"
     },
     "Microsoft.AspNetCore.StaticFiles": {
-      "name": "Microsoft.AspNetCore.StaticFiles",
-      "version":"1.1.3",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.StaticFiles",
+      "version": "1.1.3"
     },
     "Microsoft.EntityFrameworkCore.Design": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.EntityFrameworkCore.Design",
-      "version":"1.1.6",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.6"
+    },
     "Microsoft.EntityFrameworkCore.Sqlite": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.EntityFrameworkCore.Sqlite",
-      "version":"1.1.6",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.6"
+    },
     "Microsoft.EntityFrameworkCore.Sqlite.Design": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.EntityFrameworkCore.Sqlite.Design",
-      "version":"1.1.6",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.6"
+    },
     "Microsoft.EntityFrameworkCore.Tools": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.EntityFrameworkCore.Tools",
-      "version":"1.1.6",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.6"
+    },
     "Microsoft.Extensions.Configuration.UserSecrets": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.Extensions.Configuration.UserSecrets",
-      "version":"1.1.2",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.2"
+    },
     "Microsoft.Extensions.Logging.Debug": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.Extensions.Logging.Debug",
-      "version":"1.1.2",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.2"
+    },
     "Microsoft.VisualStudio.Web.CodeGeneration.Design": {
+      "depType": "prod",
+      "dependencies": {},
       "name": "Microsoft.VisualStudio.Web.CodeGeneration.Design",
-      "version":"1.1.5",
-      "depType": "prod",
-      "dependencies": {}
-      },
+      "version": "1.1.5"
+    },
     "newtonsoft.json": {
-      "name": "newtonsoft.json",
-      "version":"11.0.2",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "newtonsoft.json",
+      "version": "11.0.2"
+    },
+    "Microsoft.CSharp": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.CSharp",
+      "version": ""
+    },
+    "System.Web.DynamicData": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.DynamicData",
+      "version": ""
+    },
+    "System.Web.Entity": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.Entity",
+      "version": ""
+    },
+    "System.Web.ApplicationServices": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.ApplicationServices",
+      "version": ""
+    },
+    "System.ComponentModel.DataAnnotations": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.ComponentModel.DataAnnotations",
+      "version": ""
+    },
+    "System": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System",
+      "version": ""
+    },
+    "System.Console": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Console",
+      "version": "4.0.0.0"
+    },
+    "Microsoft.Web.Infrastructure": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.Web.Infrastructure",
+      "version": ""
+    },
+    "Newtonsoft.Json": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Newtonsoft.Json",
+      "version": "10.0.0.0"
+    },
+    "nunit.framework": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "nunit.framework",
+      "version": "3.8.1.0"
+    },
+    "Orleans": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Orleans",
+      "version": "1.4.0.0"
     }
-  }
+  },
+  "hasDevDependencies": false,
+  "name": "Simple-Project-Name",
+  "version": ""
 }

--- a/test/fixtures/dotnet-core-simple-project/simple-project.csproj
+++ b/test/fixtures/dotnet-core-simple-project/simple-project.csproj
@@ -9,6 +9,30 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include=" Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.6" />

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj-without-dev.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj-without-dev.json
@@ -1,13 +1,37 @@
 {
-  "name": "simple-project-with-dev",
-  "version": "",
-  "hasDevDependencies": true,
   "dependencies": {
     "NLog": {
-      "name": "NLog",
-      "version": "4.3.10",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "NLog",
+      "version": "4.3.10"
+    },
+    "System.Web.Entity": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.Entity",
+      "version": ""
+    },
+    "System.Web.ApplicationServices": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.ApplicationServices",
+      "version": ""
+    },
+    "nunit.framework": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "nunit.framework",
+      "version": "3.8.1.0"
+    },
+    "Orleans": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Orleans",
+      "version": "1.4.0.0"
     }
-  }
+  },
+  "hasDevDependencies": true,
+  "name": "simple-project-with-dev",
+  "version": ""
 }

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj.json
@@ -1,19 +1,43 @@
 {
-  "name": "simple-project-with-dev",
-  "version": "",
-  "hasDevDependencies": true,
   "dependencies": {
     "jQuery": {
-      "name": "jQuery",
-      "version": "3.1.1",
       "depType": "dev",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "jQuery",
+      "version": "3.1.1"
     },
     "NLog": {
-      "name": "NLog",
-      "version": "4.3.10",
       "depType": "prod",
-      "dependencies": {}
+      "dependencies": {},
+      "name": "NLog",
+      "version": "4.3.10"
+    },
+    "System.Web.Entity": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.Entity",
+      "version": ""
+    },
+    "System.Web.ApplicationServices": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Web.ApplicationServices",
+      "version": ""
+    },
+    "nunit.framework": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "nunit.framework",
+      "version": "3.8.1.0"
+    },
+    "Orleans": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Orleans",
+      "version": "1.4.0.0"
     }
-  }
+  },
+  "hasDevDependencies": true,
+  "name": "simple-project-with-dev",
+  "version": ""
 }

--- a/test/fixtures/dotnet-simple-project-with-devDeps/simple-project-with-dev.csproj
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/simple-project-with-dev.csproj
@@ -6,4 +6,14 @@
     <PackageReference Include="jQuery" Version="3.1.1" developmentDependency="true" />
     <PackageReference Include="NLog" Version="4.3.10" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/test/lib/index.ts
+++ b/test/lib/index.ts
@@ -124,7 +124,7 @@ test('.Net .csproj core dotnet-invalid-manifest throws', async (t) => {
   );
 });
 
-test('.Net dotnet-simple-project-with-devDeps tree generated as expected', async (t) => {
+test('.Net dotnet-simple-project-with-devDeps with includeDev=false tree generated as expected', async (t) => {
   const includeDev = false;
   const tree = await buildDepTreeFromFiles(
     `${__dirname}/../fixtures/dotnet-simple-project-with-devDeps`,


### PR DESCRIPTION
- Start saving more deps that are definedin `*.csproj` files in format:

```
<Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath
</Reference>

```
and 
```   
 <Reference Include="System.Web.ApplicationServices" />
```

- Added some tests

Note: dependency Type is for now assumed prod until we determine correct way to tell it is a dev dep