### PR TITLE
feat: added .fsproj support

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,8 +7,9 @@ import {PkgTree, DepType, parseManifestFile,
   getDependencyTreeFromPackagesConfig, getDependencyTreeFromProjectFile} from './parsers';
 
 const PROJ_FILE_EXTENSION = [
-    '.csproj',
-    '.vbproj',
+  '.csproj',
+  '.vbproj',
+  '.fsproj',
 ];
 
 export {

--- a/test/fixtures/dotnet-fs-simple-project/expected-tree.json
+++ b/test/fixtures/dotnet-fs-simple-project/expected-tree.json
@@ -1,0 +1,25 @@
+{
+  "dependencies": {
+    "log4net": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "log4net",
+      "version": "2.0.8"
+    },
+    "Microsoft.AspNetCore.App": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.App",
+      "version": null
+    },
+    "MySql.Data": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "MySql.Data",
+      "version": "8.0.12"
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "",
+  "version": ""
+}

--- a/test/fixtures/dotnet-fs-simple-project/manifest.fsproj
+++ b/test/fixtures/dotnet-fs-simple-project/manifest.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Controllers/ValuesController.fs" />
+    <Compile Include="Startup.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="MySql.Data" Version="8.0.12" />
+  </ItemGroup>
+
+</Project>

--- a/test/lib/index.ts
+++ b/test/lib/index.ts
@@ -20,6 +20,15 @@ test('.Net Visual Basic project tree generated as expected', async (t) => {
     t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
+test('.Net F# project tree generated as expected', async (t) => {
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-fs-simple-project`,
+    'manifest.fsproj',
+    false);
+  const expectedTree = load('dotnet-fs-simple-project/expected-tree.json');
+  t.deepEqual(tree, expectedTree, 'trees are equal');
+});
+
 test('.Net simple project tree generated as expected', async (t) => {
   const includeDev = false;
   const tree = await buildDepTreeFromFiles(


### PR DESCRIPTION
Currently we can parse `packages.config`, `.csproj` or `.vbproj`. But `.fsproj` files is identical to `.csproj`.

This PR adds:

- `.fsproj` to available extensions list
- test for generic F# project

https://snyksec.atlassian.net/browse/SC-6470

