### PR TITLE
feat: send InvalidUserInputError for invalid files

### DIFF
--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,0 +1,1 @@
+export {InvalidUserInputError} from './invalid-user-input-error';

--- a/lib/errors/invalid-user-input-error.ts
+++ b/lib/errors/invalid-user-input-error.ts
@@ -1,0 +1,9 @@
+export class InvalidUserInputError extends Error {
+  public code = 422;
+  public name = 'InvalidUserInputError';
+
+  constructor(...args) {
+    super(...args);
+    Error.captureStackTrace(this, InvalidUserInputError);
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,35 +26,23 @@ export {
 };
 
 function buildDepTreeFromProjectJson(manifestFileContents: string, includeDev = false): PkgTree {
-  try {
-    // trimming required to address files with UTF-8 with BOM encoding
-    const manifestFile: ProjectJsonManifest = JSON.parse(manifestFileContents.trim());
-    return getDependencyTreeFromProjectJson(manifestFile, includeDev);
-  } catch (err) {
-    throw new Error(`Building dependency tree failed with error: ${err.message}`);
-  }
+  // trimming required to address files with UTF-8 with BOM encoding
+  const manifestFile: ProjectJsonManifest = JSON.parse(manifestFileContents.trim());
+  return getDependencyTreeFromProjectJson(manifestFile, includeDev);
 }
 
 async function buildDepTreeFromPackagesConfig(
     manifestFileContents: string,
     includeDev = false): Promise<PkgTree> {
-  try {
-    const manifestFile: any = await parseManifestFile(manifestFileContents);
-    return getDependencyTreeFromPackagesConfig(manifestFile, includeDev);
-  } catch (err) {
-    throw new Error(`Building dependency tree failed with error: ${err.message}`);
-  }
+  const manifestFile: any = await parseManifestFile(manifestFileContents);
+  return getDependencyTreeFromPackagesConfig(manifestFile, includeDev);
 }
 
 async function buildDepTreeFromProjectFile(
     manifestFileContents: string,
     includeDev = false): Promise<PkgTree> {
-  try {
-    const manifestFile: any = await parseManifestFile(manifestFileContents);
-    return getDependencyTreeFromProjectFile(manifestFile, includeDev);
-  } catch (err) {
-    throw new Error(`Building dependency tree failed with error ${err.message}`);
-  }
+  const manifestFile: any = await parseManifestFile(manifestFileContents);
+  return getDependencyTreeFromProjectFile(manifestFile, includeDev);
 }
 
 function buildDepTreeFromFiles(

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,5 +1,6 @@
 import * as parseXML from 'xml2js';
 import * as _ from 'lodash';
+import {InvalidUserInputError} from '../errors';
 
 export interface PkgTree {
   name: string;
@@ -225,12 +226,13 @@ function buildSubTreeFromPackageReference(dep, isDev: boolean): PkgTree {
 export async function parseManifestFile(manifestFileContents: string) {
   return new Promise((resolve, reject) => {
     parseXML
-      .parseString(manifestFileContents, (err, result) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(result);
-      });
+    .parseString(manifestFileContents, (err, result) => {
+      if (err) {
+        const e = new InvalidUserInputError('manifest parsing failed');
+        return reject(e);
+      }
+      return resolve(result);
+    });
   });
 }
 

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -6,6 +6,7 @@
 import {test} from 'tap';
 import * as fs from 'fs';
 import {buildDepTreeFromFiles} from '../../lib';
+import {InvalidUserInputError} from '../../lib/errors/invalid-user-input-error';
 
 const load = (filename) => JSON.parse(
   fs.readFileSync(`${__dirname}/../fixtures/${filename}`, 'utf8'),
@@ -70,11 +71,15 @@ test('.Net dotnet-empty-manifest returns empty tree', async (t) => {
 });
 
 test('.Net dotnet-invalid-manifest throws', async (t) => {
+  const invalidUserInputError = new InvalidUserInputError('manifest parsing failed');
+
   const includeDev = false;
   t.rejects(buildDepTreeFromFiles(
-    `${__dirname}/../fixtures/dotnet-invalid-manifest`,
-    'packages.config',
-    includeDev),
+      `${__dirname}/../fixtures/dotnet-invalid-manifest`,
+      'packages.config',
+      includeDev),
+    invalidUserInputError,
+    'Wrong error obtained',
   );
 });
 
@@ -133,11 +138,15 @@ test('.Net .csproj dotnet-empty-manifest returns empty tree', async (t) => {
 });
 
 test('.Net .csproj core dotnet-invalid-manifest throws', async (t) => {
+  const invalidUserInputError = new InvalidUserInputError('manifest parsing failed');
+
   const includeDev = false;
   t.rejects(buildDepTreeFromFiles(
     `${__dirname}/../fixtures/dotnet-invalid-manifest`,
     'invalid.csproj',
     includeDev),
+    invalidUserInputError,
+    'Wrong error obtained',
   );
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Parser will now send InvalidUserInputError when failing on invalid files, instead of sending 500 error