### PR TITLE
fix: Support for targetFramework and targetFrameworkVersion

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -246,23 +246,26 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   const propertyList = projectPropertyGroup
     .find((propertyGroup) => {
         return _.has(propertyGroup, 'TargetFramework')
+        || _.has(propertyGroup, 'TargetFrameworks')
         || _.has(propertyGroup, 'TargetFrameworkVersion');
       }) || {};
-  // tslint:disable
+
   if (_.isEmpty(propertyList)) {
     return targetFrameworksResult;
   }
-
-  if (propertyList.TargetFramework) {
-    for (const item of propertyList.TargetFramework) {
+  // tslint:disable
+  if (propertyList.TargetFrameworks) {
+    for (const item of propertyList.TargetFrameworks) {
       targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
     }
   }
 
   if (propertyList.TargetFrameworkVersion) {
-    for (const item of propertyList.TargetFrameworkVersion) {
-      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
-    }
+    targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFrameworkVersion];
+  }
+
+  if (propertyList.TargetFramework) {
+    targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFramework];
   }
 
   return targetFrameworksResult;

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -253,20 +253,20 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   if (_.isEmpty(propertyList)) {
     return targetFrameworksResult;
   }
-  // tslint:disable
+  // TargetFrameworks is expected to be a list ; separated
   if (propertyList.TargetFrameworks) {
     for (const item of propertyList.TargetFrameworks) {
       targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
     }
   }
-
+  // TargetFrameworks is expected to be a string
   if (propertyList.TargetFrameworkVersion) {
     targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFrameworkVersion];
   }
-
+  // TargetFrameworks is expected to be a string
   if (propertyList.TargetFramework) {
     targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFramework];
   }
 
-  return targetFrameworksResult;
+  return _.uniq(targetFrameworksResult);
 }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -244,13 +244,25 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
     return targetFrameworksResult;
   }
   const propertyList = projectPropertyGroup
-    .find((propertyGroup) => _.has(propertyGroup, 'TargetFramework'));
-
-  if (!propertyList) {
+    .find((propertyGroup) => {
+        return _.has(propertyGroup, 'TargetFramework')
+        || _.has(propertyGroup, 'TargetFrameworkVersion');
+      }) || {};
+  // tslint:disable
+  if (_.isEmpty(propertyList)) {
     return targetFrameworksResult;
   }
-  for (const targetFramework of propertyList.TargetFramework) {
-    targetFrameworksResult = [...targetFrameworksResult, ...targetFramework.split(';')];
+
+  if (propertyList.TargetFramework) {
+    for (const item of propertyList.TargetFramework) {
+      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
+    }
+  }
+
+  if (propertyList.TargetFrameworkVersion) {
+    for (const item of propertyList.TargetFrameworkVersion) {
+      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
+    }
   }
 
   return targetFrameworksResult;

--- a/test/fixtures/dotnet-core-simple-project/simple-project.csproj
+++ b/test/fixtures/dotnet-core-simple-project/simple-project.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1;netcoreapp1.2</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp1.2</TargetFrameworks>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
     <UserSecretsId>aspnet-simple_project-2905A172-2378-4427-901F-971E0933141A</UserSecretsId>
     <AssemblyName>Simple-Project-Name</AssemblyName>

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -6,7 +6,7 @@
 import {test} from 'tap';
 import * as fs from 'fs';
 import {buildDepTreeFromFiles} from '../../lib';
-import {InvalidUserInputError} from '../../lib/errors/invalid-user-input-error';
+import {InvalidUserInputError} from '../../lib/errors';
 
 const load = (filename) => JSON.parse(
   fs.readFileSync(`${__dirname}/../fixtures/${filename}`, 'utf8'),

--- a/test/lib/target-frameworks.test.ts
+++ b/test/lib/target-frameworks.test.ts
@@ -43,22 +43,12 @@ test('.Net .csproj dotnet-empty-manifest target framework extracted', async (t) 
   t.deepEqual(targetFrameworks, [], 'targetFramework array is as expected');
 });
 
-/*
-****** vbproj ******
-*/
-
-test('.Net .csproj simple project target framework extracted as expected', async (t) => {
-  const targetFrameworks = await extractTargetFrameworksFromFiles(
-    `${__dirname}/../fixtures/dotnet-vb-simple-project`,
-    'manifest.vbproj');
-  t.deepEqual(targetFrameworks, ['v4.6.1'], 'targetFramework array is as expected');
-});
 
 /*
 ****** fsproj ******
 */
 
-test('.Net .csproj simple project target framework extracted as expected', async (t) => {
+test('.Net .fsproj simple project target framework extracted as expected', async (t) => {
   const targetFrameworks = await extractTargetFrameworksFromFiles(
     `${__dirname}/../fixtures/dotnet-fs-simple-project`,
     'manifest.fsproj');

--- a/test/lib/target-frameworks.test.ts
+++ b/test/lib/target-frameworks.test.ts
@@ -15,7 +15,7 @@ test('.Net Visual Basic project target framework extracted as expected', async (
     const targetFrameworks = await extractTargetFrameworksFromFiles(
         `${__dirname}/../fixtures/dotnet-vb-simple-project`,
         'manifest.vbproj');
-    t.deepEqual(targetFrameworks, [], 'targetFramework array is as expected');
+    t.deepEqual(targetFrameworks, ['v4.6.1'], 'targetFramework array is as expected');
 });
 
 test('.Net F# project target framework extracted as expected', async (t) => {
@@ -41,4 +41,26 @@ test('.Net .csproj dotnet-empty-manifest target framework extracted', async (t) 
     `${__dirname}/../fixtures/dotnet-empty-manifest`,
     'empty-manifest.csproj');
   t.deepEqual(targetFrameworks, [], 'targetFramework array is as expected');
+});
+
+/*
+****** vbproj ******
+*/
+
+test('.Net .csproj simple project target framework extracted as expected', async (t) => {
+  const targetFrameworks = await extractTargetFrameworksFromFiles(
+    `${__dirname}/../fixtures/dotnet-vb-simple-project`,
+    'manifest.vbproj');
+  t.deepEqual(targetFrameworks, ['v4.6.1'], 'targetFramework array is as expected');
+});
+
+/*
+****** fsproj ******
+*/
+
+test('.Net .csproj simple project target framework extracted as expected', async (t) => {
+  const targetFrameworks = await extractTargetFrameworksFromFiles(
+    `${__dirname}/../fixtures/dotnet-fs-simple-project`,
+    'manifest.fsproj');
+  t.deepEqual(targetFrameworks, ['netcoreapp2.1'], 'targetFramework array is as expected');
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Add missing support for `targetFrameworkVersion` property which is the same as `targetFramework`
- Split out `targetFramework` from `targetFrameworks`:  
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#implicit-package-references

We use `targetFramework` for 1 and `targetFrameworks` for multiple
Looks like for `targetFrameworkVersion` it is always 1 https://www.cyotek.com/blog/targeting-multiple-versions-of-the-net-framework-from-the-same-project

https://snyksec.atlassian.net/browse/BST-241