### PR TITLE
fix: added missing export `extractTargetFrameworksFromProjectConfig`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,7 @@ export {
   buildDepTreeFromFiles,
   extractTargetFrameworksFromFiles,
   extractTargetFrameworksFromProjectFile,
+  extractTargetFrameworksFromProjectConfig,
   PkgTree,
   DepType,
 };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Added missing export `extractTargetFrameworksFromProjectConfig`.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-272