### PR TITLE
feat: Support for package version set as xml variables

### DIFF
--- a/test/fixtures/dotnet-core-variable-version/expected-tree.json
+++ b/test/fixtures/dotnet-core-variable-version/expected-tree.json
@@ -1,0 +1,25 @@
+{
+  "name": "Project-Name",
+  "version": "",
+  "hasDevDependencies": false,
+  "dependencies": {
+    "Newtonsoft.Json": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Newtonsoft.Json",
+      "version": "11.0.2"
+    },
+    "Newtonsoft.Json.Schema": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Newtonsoft.Json.Schema",
+      "version": "3.0.10"
+    },
+    "System.CommandLine": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.CommandLine",
+      "version": "0.1.0-e160909-1"
+    }
+  }
+}

--- a/test/fixtures/dotnet-core-variable-version/manifest.csproj
+++ b/test/fixtures/dotnet-core-variable-version/manifest.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Found on https://github.com/dotnet/coreclr/blob/master/tests/src/Common/CoreFX/TestFileSetup/CoreFX.TestUtils.TestFileSetup.csproj -->
+  <Import Project="..\..\..\..\..\dependencies.props" />
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyName>Project-Name</AssemblyName>
+    <SystemCommandLineVersion>0.1.0-e160909-1</SystemCommandLineVersion>
+    <NewtonsoftJsonVersion>11.0.2</NewtonsoftJsonVersion>
+    <NewtonsoftJsonSchemaVersion>3.0.10</NewtonsoftJsonSchemaVersion>
+    <XunitPackageVersion>2.3.0-beta1-build3642</XunitPackageVersion>
+    <!-- Due to an API surface mismatch, if the xunit.netcore executable attempts to run the wrong version of the
+        runner utility, running the tests wil break, so separate both into different version definitions  -->
+    <XunitRunnerUtilityVersion>2.2.0-beta2-build3300</XunitRunnerUtilityVersion>
+    <XunitAbstractionsVersion>2.0.1</XunitAbstractionsVersion>
+    <XunitNetcoreExtensionsVersion>2.1.0-preview2-02516-02</XunitNetcoreExtensionsVersion>
+    <CoreFxTestUtilitiesVersion>4.5.0-preview2-26219-0</CoreFxTestUtilitiesVersion>
+    <RestoreSources>$(RestoreSources);https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json</RestoreSources>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>$(NewtonsoftJsonVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json.Schema">
+      <Version>$(NewtonsoftJsonSchemaVersion)</Version>
+    </PackageReference>
+    <!-- TODO Remove this reference - System.CommandLine is now archived and not under active development -->
+    <PackageReference Include="System.CommandLine">
+      <Version>$(SystemCommandLineVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -117,6 +117,16 @@ test('.Net .csproj simple project tree generated as expected', async (t) => {
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
+test('.Net .csproj simple project tree generated as expected for variable package versions', async (t) => {
+  const includeDev = false;
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-core-variable-version`,
+    'manifest.csproj',
+    includeDev);
+  const expectedTree = load('dotnet-core-variable-version/expected-tree.json');
+  t.deepEqual(tree, expectedTree, 'trees are equal');
+});
+
 test('.Net .csproj dotnet-no-packages empty tree generated as expected', async (t) => {
   const includeDev = false;
   const tree = await buildDepTreeFromFiles(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
I found a project in the wild that shows you can use variables in the XML for versions just like in Maven,
here is an implementation for this for .proj files only.

#### Where should the reviewer start?

Check the fixture
#### How should this be manually tested?

Run the tests
