### PR TITLE
Get deptree for target framework

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as _ from 'lodash';
 
-import {PkgTree, DepType, parseManifestFile,
+import {PkgTree, DotnetDepsPkgTree, DepType, parseManifestFile,
   getDependencyTreeFromPackagesConfig, getDependencyTreeFromProjectJson,
   getDependencyTreeFromProjectFile, ProjectJsonManifest,
   getTargetFrameworksFromProjectFile,
@@ -35,10 +35,9 @@ function buildDepTreeFromProjectJson(manifestFileContents: string, includeDev = 
 
 async function buildDepTreeFromPackagesConfig(
     manifestFileContents: string,
-    includeDev = false,
-    targetFramework?: string): Promise<PkgTree> {
+    includeDev = false): Promise<DotnetDepsPkgTree> {
   const manifestFile: any = await parseManifestFile(manifestFileContents);
-  return getDependencyTreeFromPackagesConfig(manifestFile, includeDev, targetFramework);
+  return getDependencyTreeFromPackagesConfig(manifestFile, includeDev);
 }
 
 async function buildDepTreeFromProjectFile(
@@ -67,7 +66,7 @@ function buildDepTreeFromFiles(
   if (_.includes(PROJ_FILE_EXTENSIONS, manifestFileExtension)) {
     return buildDepTreeFromProjectFile(manifestFileContents, includeDev);
   } else if (_.endsWith(manifestFilePath, 'packages.config')) {
-    return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev, targetFramework);
+    return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev);
   } else if (_.endsWith(manifestFilePath, 'project.json')) {
     return buildDepTreeFromProjectJson(manifestFileContents, includeDev);
   } else {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,7 +48,7 @@ async function buildDepTreeFromProjectFile(
 }
 
 function buildDepTreeFromFiles(
-  root: string, manifestFilePath: string, includeDev = false, targetFramework?: string) {
+  root: string, manifestFilePath: string, includeDev = false) {
   if (!root || !manifestFilePath) {
     throw new Error('Missing required parameters for buildDepTreeFromFiles()');
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,9 +35,10 @@ function buildDepTreeFromProjectJson(manifestFileContents: string, includeDev = 
 
 async function buildDepTreeFromPackagesConfig(
     manifestFileContents: string,
-    includeDev = false): Promise<PkgTree> {
+    includeDev = false,
+    targetFramework?: string): Promise<PkgTree> {
   const manifestFile: any = await parseManifestFile(manifestFileContents);
-  return getDependencyTreeFromPackagesConfig(manifestFile, includeDev);
+  return getDependencyTreeFromPackagesConfig(manifestFile, includeDev, targetFramework);
 }
 
 async function buildDepTreeFromProjectFile(
@@ -48,7 +49,7 @@ async function buildDepTreeFromProjectFile(
 }
 
 function buildDepTreeFromFiles(
-  root: string, manifestFilePath: string, includeDev = false) {
+  root: string, manifestFilePath: string, includeDev = false, targetFramework?: string) {
   if (!root || !manifestFilePath) {
     throw new Error('Missing required parameters for buildDepTreeFromFiles()');
   }
@@ -66,7 +67,7 @@ function buildDepTreeFromFiles(
   if (_.includes(PROJ_FILE_EXTENSIONS, manifestFileExtension)) {
     return buildDepTreeFromProjectFile(manifestFileContents, includeDev);
   } else if (_.endsWith(manifestFilePath, 'packages.config')) {
-    return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev);
+    return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev, targetFramework);
   } else if (_.endsWith(manifestFilePath, 'project.json')) {
     return buildDepTreeFromProjectJson(manifestFileContents, includeDev);
   } else {

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -82,7 +82,8 @@ function buildSubTreeFromProjectJson(name, version, isDev: boolean): PkgTree {
   return depSubTree;
 }
 
-export async function getDependencyTreeFromPackagesConfig(manifestFile, includeDev: boolean = false) {
+export async function getDependencyTreeFromPackagesConfig(
+  manifestFile, includeDev: boolean = false, targetFramework?: string) {
   const depTree: PkgTree = {
     dependencies: {},
     hasDevDependencies: false,
@@ -96,7 +97,8 @@ export async function getDependencyTreeFromPackagesConfig(manifestFile, includeD
     const depName = dep.$.id;
     const isDev = !!dep.$.developmentDependency;
     depTree.hasDevDependencies = depTree.hasDevDependencies || isDev;
-    if (isDev && !includeDev) {
+    if ((isDev && !includeDev) ||
+      (targetFramework && dep.$.targetFramework && dep.$.targetFramework !== targetFramework)) {
       continue;
     }
     depTree.dependencies[depName] = buildSubTreeFromPackagesConfig(dep, isDev);

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -296,6 +296,9 @@ export function getTargetFrameworksFromProjectConfig(manifestFile) {
   const packages = _.get(manifestFile, 'packages.package', []);
 
   packages.forEach((item) => {
+    if (!item.$.targetFramework) {
+      return;
+    }
     const targetFramework = item.$.targetFramework;
 
     if (!_.includes(targetFrameworksResult, targetFramework)) {

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -87,7 +87,7 @@ function buildSubTreeFromProjectJson(name, version, isDev: boolean): PkgTree {
 }
 
 export async function getDependencyTreeFromPackagesConfig(
-  manifestFile, includeDev: boolean = false) {
+  manifestFile, includeDev: boolean = false): Promise<DotnetDepsPkgTree> {
   const depTree: PkgTree = {
     dependencies: {},
     hasDevDependencies: false,
@@ -298,20 +298,19 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
 }
 
 export function getTargetFrameworksFromProjectConfig(manifestFile) {
-  let targetFrameworksResult: string[] = [];
-
+  const targetFrameworksResult: string[] = [];
   const packages = _.get(manifestFile, 'packages.package', []);
 
-  packages.forEach((item) => {
-    if (!item.$.targetFramework) {
-      return;
-    }
+  for (const item of packages) {
     const targetFramework = item.$.targetFramework;
+    if (!targetFramework) {
+      continue;
+    }
 
     if (!_.includes(targetFrameworksResult, targetFramework)) {
-      targetFrameworksResult = [...targetFrameworksResult, targetFramework];
+      targetFrameworksResult.push(targetFramework);
     }
-  });
+  }
 
   return targetFrameworksResult;
 }

--- a/test/fixtures/dotnet-movie-hunter-api/expected-tree.json
+++ b/test/fixtures/dotnet-movie-hunter-api/expected-tree.json
@@ -4,114 +4,133 @@
       "depType": "prod",
       "dependencies": {},
       "name": "Antlr",
+      "targetFramework": "net451",
       "version": "3.4.1.9004"
     },
     "bootstrap": {
       "depType": "prod",
       "dependencies": {},
       "name": "bootstrap",
+      "targetFramework": "net451",
       "version": "3.0.0"
     },
     "jQuery": {
       "depType": "prod",
       "dependencies": {},
       "name": "jQuery",
+      "targetFramework": "net451",
       "version": "1.10.2"
     },
     "Microsoft.AspNet.Cors": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.Cors",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.Mvc": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.Mvc",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.Razor": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.Razor",
+      "targetFramework": "net451",
       "version": "3.1.2"
     },
     "Microsoft.AspNet.Web.Optimization": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.Web.Optimization",
+      "targetFramework": "net451",
       "version": "1.1.3"
     },
     "Microsoft.AspNet.WebApi": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebApi.Client": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi.Client",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebApi.Core": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi.Core",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebApi.Cors": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi.Cors",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebApi.HelpPage": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi.HelpPage",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebApi.WebHost": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebApi.WebHost",
+      "targetFramework": "net451",
       "version": "5.1.2"
     },
     "Microsoft.AspNet.WebPages": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.AspNet.WebPages",
+      "targetFramework": "net451",
       "version": "3.1.2"
     },
     "Microsoft.Web.Infrastructure": {
       "depType": "prod",
       "dependencies": {},
       "name": "Microsoft.Web.Infrastructure",
+      "targetFramework": "net451",
       "version": "1.0.0.0"
     },
     "Modernizr": {
       "depType": "prod",
       "dependencies": {},
       "name": "Modernizr",
+      "targetFramework": "net451",
       "version": "2.6.2"
     },
     "Newtonsoft.Json": {
       "depType": "prod",
       "dependencies": {},
       "name": "Newtonsoft.Json",
+      "targetFramework": "net451",
       "version": "5.0.6"
     },
     "Respond": {
       "depType": "prod",
       "dependencies": {},
       "name": "Respond",
+      "targetFramework": "net451",
       "version": "1.2.0"
     },
     "WebGrease": {
       "depType": "prod",
       "dependencies": {},
       "name": "WebGrease",
+      "targetFramework": "net451",
       "version": "1.5.2"
     }
   },

--- a/test/fixtures/dotnet-multiple-target-frameworks/expected-tree-net46.json
+++ b/test/fixtures/dotnet-multiple-target-frameworks/expected-tree-net46.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {
+    "jQuery": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "jQuery",
+      "version": "3.1.1"
+    },
+    "NLog": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "NLog",
+      "version": "4.3.10"
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "",
+  "version": ""
+}

--- a/test/fixtures/dotnet-multiple-target-frameworks/expected-tree-net46.json
+++ b/test/fixtures/dotnet-multiple-target-frameworks/expected-tree-net46.json
@@ -4,13 +4,21 @@
       "depType": "prod",
       "dependencies": {},
       "name": "jQuery",
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "targetFramework": "net46"
     },
     "NLog": {
       "depType": "prod",
       "dependencies": {},
       "name": "NLog",
       "version": "4.3.10"
+    },
+    "bootstrap": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "bootstrap",
+      "version": "3.0.0",
+      "targetFramework": "net451"
     }
   },
   "hasDevDependencies": false,

--- a/test/fixtures/dotnet-multiple-target-frameworks/packages.config
+++ b/test/fixtures/dotnet-multiple-target-frameworks/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="jQuery" version="3.1.1" targetFramework="net46" />
-  <package id="NLog" version="4.3.10" targetFramework="net46" />
+  <package id="NLog" version="4.3.10" />
   <package id="bootstrap" version="3.0.0" targetFramework="net451" />
 </packages>

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-without-dev.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-without-dev.json
@@ -7,6 +7,7 @@
       "name": "NLog",
       "version": "4.3.10",
       "depType": "prod",
+      "targetFramework": "net46",
       "dependencies": {}
     }
   }

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree.json
@@ -7,12 +7,14 @@
       "name": "jQuery",
       "version": "3.1.1",
       "depType": "dev",
+      "targetFramework": "net46",
       "dependencies": {}
     },
     "NLog": {
       "name": "NLog",
       "version": "4.3.10",
       "depType": "prod",
+      "targetFramework": "net46",
       "dependencies": {}
     }
   }

--- a/test/fixtures/dotnet-simple-project/expected-tree.json
+++ b/test/fixtures/dotnet-simple-project/expected-tree.json
@@ -7,12 +7,14 @@
       "name": "jQuery",
       "version": "3.1.1",
       "depType": "prod",
+      "targetFramework": "net46",
       "dependencies": {}
     },
     "NLog": {
       "name": "NLog",
       "version": "4.3.10",
       "depType": "prod",
+      "targetFramework": "net46",
       "dependencies": {}
     }
   }

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -103,6 +103,17 @@ test('.Net dotnet-simple-project-with-devDeps tree generated as expected', async
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
+test('.Net packages.config with multiple target frameworks is limited to selected framework', async (t) => {
+  const includeDev = false;
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-multiple-target-frameworks`,
+    'packages.config',
+    includeDev,
+    'net46');
+  const expectedTree = load('dotnet-multiple-target-frameworks/expected-tree-net46.json');
+  t.deepEqual(tree, expectedTree, 'trees are equal');
+});
+
 /*
 ****** csproj ******
 */

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -103,13 +103,12 @@ test('.Net dotnet-simple-project-with-devDeps tree generated as expected', async
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
-test('.Net packages.config with multiple target frameworks is limited to selected framework', async (t) => {
+test('.Net packages.config with multiple target frameworks tree generated as expected', async (t) => {
   const includeDev = false;
   const tree = await buildDepTreeFromFiles(
     `${__dirname}/../fixtures/dotnet-multiple-target-frameworks`,
     'packages.config',
-    includeDev,
-    'net46');
+    includeDev);
   const expectedTree = load('dotnet-multiple-target-frameworks/expected-tree-net46.json');
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Allows filtering dependencies in `packages.config` file per their targetFramework specification.
