### PR TITLE
fix: resolve <TargetFrameworkVersion> properly

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -310,9 +310,11 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
       targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
     }
   }
-  // TargetFrameworks is expected to be a string
+  // TargetFrameworkVersion is expected to be a string containing only one item
+  // TargetFrameworkVersion also implies .NETFramework, for convenience
+  // return longer version
   if (propertyList.TargetFrameworkVersion) {
-    targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFrameworkVersion];
+    targetFrameworksResult.push(`.NETFramework,Version=${propertyList.TargetFrameworkVersion[0]}`);
   }
   // TargetFrameworks is expected to be a string
   if (propertyList.TargetFramework) {

--- a/test/lib/target-frameworks.test.ts
+++ b/test/lib/target-frameworks.test.ts
@@ -15,7 +15,7 @@ test('.Net Visual Basic project target framework extracted as expected', async (
     const targetFrameworks = await extractTargetFrameworksFromFiles(
         `${__dirname}/../fixtures/dotnet-vb-simple-project`,
         'manifest.vbproj');
-    t.deepEqual(targetFrameworks, ['v4.6.1'], 'targetFramework array is as expected');
+    t.deepEqual(targetFrameworks, ['.NETFramework,Version=v4.6.1'], 'targetFramework array is as expected');
 });
 
 test('.Net F# project target framework extracted as expected', async (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes parsing of `<TargetFrameworkVersion>`