### PR TITLE
fix: do not fail parsing of .Net projects when dependency version is …

### DIFF
--- a/test/fixtures/dotnet-variables/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
+++ b/test/fixtures/dotnet-variables/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\versions.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Steeltoe.Extensions.Configuration.CloudFoundryAutofac\Steeltoe.Extensions.Configuration.CloudFoundryAutofac.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitStudioVersion)" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <NoWarn>SA1101;SA1124;SA1201;SA1309;SA1310;SA1401;SA1600;SA1652;1591</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json">
+      <Link>stylecop.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </AdditionalFiles>
+  </ItemGroup>
+
+</Project>

--- a/test/lib/variables.test.ts
+++ b/test/lib/variables.test.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+// Shebang is required, and file *has* to be executable: chmod +x file.test.js
+// See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
+// tslint:disable:max-line-length
+// tslint:disable:object-literal-key-quotes
+import { test } from 'tap';
+import * as fs from 'fs';
+import { buildDepTreeFromProjectFile } from '../../lib';
+
+/*
+****** csproj ******
+*/
+test('.Net C# project with variable is parsed', async (t) => {
+  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-variables/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj`, 'utf-8');
+  const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
+  t.ok(depTree);
+  t.ok(depTree.dependenciesWithUnknownVersions);
+  t.equal(depTree.dependenciesWithUnknownVersions!.length, 4);
+});
+


### PR DESCRIPTION
…a variable not found in manifest.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

We also collect dependencies with unknown versions into a new field of the `PkgTree` type

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-407

#### Screenshots


#### Additional questions
