### PR TITLE
test: When dep is seen  more than once, use first seen to match nuget…

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -145,10 +145,12 @@ export async function getDependencyTreeFromProjectFile(manifestFile, includeDev:
   const referenceIncludeDeps =
     await getDependenciesFromReferenceInclude(manifestFile, includeDev);
 
+  // order matters, the order deps are parsed in needs to be preserved and first seen kept
+  // so applying the packageReferenceDeps last to override the second parsed
   const depTree: PkgTree = {
     dependencies: {
-      ...packageReferenceDeps.dependencies,
       ...referenceIncludeDeps.dependencies,
+      ...packageReferenceDeps.dependencies,
     },
     hasDevDependencies: packageReferenceDeps.hasDevDependencies || referenceIncludeDeps.hasDevDependencies,
     name,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "npm run lint && npm run unit-test",
-    "unit-test": "tap test/lib -Rspec --timeout=300 --node-path ts-node --test-file-pattern '/\\.test\\.[tj]s$/'",
+    "unit-test": "npm run build && tap test/lib -Rspec --timeout=300 --node-path ts-node --test-file-pattern '/\\.test\\.[tj]s$/'",
     "lint": "tslint -p tsconfig.json",
     "build": "tsc",
     "build-watch": "tsc -w",

--- a/test/fixtures/old-and-new-package-format-proj/project.csproj
+++ b/test/fixtures/old-and-new-package-format-proj/project.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net471</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.ServiceBus" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
+    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="NetTopologySuite" Version="1.15.0" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="1.15.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Npgsql" Version="4.0.5" />
+    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus">
+      <HintPath>..\..\..\..\.nuget\packages\microsoft.azure.webjobs.servicebus\2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -21,6 +21,14 @@ test('.Net Visual Basic project tree generated as expected', async (t) => {
     t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
+test('.Net Visual Basic project tree generated as expected', async (t) => {
+  const tree = await buildDepTreeFromFiles(
+      `${__dirname}/../fixtures/old-and-new-package-format-proj`,
+      'project.csproj',
+      false);
+  t.equal(tree.dependencies['Microsoft.Azure.WebJobs.ServiceBus'].version, '2.2.0', 'fist package picked');
+});
+
 test('.Net F# project tree generated as expected', async (t) => {
   const tree = await buildDepTreeFromFiles(
     `${__dirname}/../fixtures/dotnet-fs-simple-project`,

--- a/test/lib/package-reference.test.ts
+++ b/test/lib/package-reference.test.ts
@@ -16,6 +16,12 @@ test('.Net C# project contains PackageReference as expected', async (t) => {
   t.true(hasPackageReference);
 });
 
+test('Project contains PackageReference as expected even if Reference Include present', async (t) => {
+  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/old-and-new-package-format-proj/project.csproj`, 'utf-8');
+  const hasPackageReference = await containsPackageReference(manifestFileContents);
+  t.true(hasPackageReference);
+});
+
 test('.Net C# project does not contain PackageReference as expected', async (t) => {
   const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-no-packagereference/project.csproj`, 'utf-8');
   const hasPackageReference = await containsPackageReference(manifestFileContents);


### PR DESCRIPTION
… rules

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Keep first seen dep in case it's present in the file more than once. This is to match the seen behaviour from 
#### Where should the reviewer start?
See the test added, we have the dep mentioned twice and previously we would pick the second defined dep with no version even though the first dep has a clear version.

#### How should this be manually tested?
`npm run test` 

Alternatively import the fixture in the test into the production app and it will fail, when using this fix and symlinking the parser to the deps service this will now pass

[Jira](https://snyksec.atlassian.net/browse/BST-544)
[Zendesk](https://snyk.zendesk.com/agent/tickets/307)