### PR TITLE
fix: handle Update property in project references

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -181,7 +181,8 @@ async function getDependenciesFromPackageReference(manifestFile, includeDev: boo
     getConditionalFrameworks(packageList.$.Condition) : [];
 
   for (const dep of packageList.PackageReference) {
-    const depName = dep.$.Include;
+    // Some .*proj files use the Update attribute instead of Include
+    const depName = dep.$.Include || dep.$.Update;
     const isDev = !!dep.$.developmentDependency;
     dependenciesResult.hasDevDependencies = dependenciesResult.hasDevDependencies || isDev;
     if (isDev && !includeDev) {
@@ -220,7 +221,9 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
    getConditionalFrameworks(referenceIncludeList.$.Condition) : [];
 
   for (const item of referenceIncludeList.Reference) {
-    const propertiesList = item.$.Include.split(',').map((i) => i.trim());
+    // Some .*proj files use the Update attribute instead of Include
+    const property = item.$.Include || item.$.Update;
+    const propertiesList = property.split(',').map((i) => i.trim());
     const [depName, ...depInfoArray] = propertiesList;
     const depInfo: ReferenceInclude = {};
 
@@ -251,12 +254,14 @@ function buildSubTreeFromPackageReference(dep, isDev: boolean, manifestFile, tar
 
   const version = extractDependencyVersion(dep, manifestFile);
 
+  // Some .*proj files use the Update attribute instead of Include
+  const dependencyName = dep.$.Include || dep.$.Update;
   if (version !== null) {
 
     const depSubTree: PkgTree = {
       depType: isDev ? DepType.dev : DepType.prod,
       dependencies: {},
-      name: dep.$.Include,
+      name: dependencyName,
       // Version could be in attributes or as child node.
       version,
     };
@@ -267,7 +272,8 @@ function buildSubTreeFromPackageReference(dep, isDev: boolean, manifestFile, tar
 
     return depSubTree;
   } else {
-    return {name: dep.$.Include, withoutVersion: true};
+    // Some .*proj files use the Update attribute instead of Include
+    return { name: dependencyName, withoutVersion: true };
   }
 }
 


### PR DESCRIPTION
Some customer projects have the Update property instead of Include, which we currently don't handle and results in errors in generating the dependency graph.
This PR fixes this problem so that dependency names are correctly pulled from the Update property.

- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What are the relevant tickets?

https://snyk.zendesk.com/agent/tickets/1315
