### PR TITLE
fix: skip reference update deps

### DIFF
--- a/test/fixtures/dotnet-fs-package-reference-update/example.fsproj
+++ b/test/fixtures/dotnet-fs-package-reference-update/example.fsproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BestEx.Framework" Version="4.10.6" />
+    <PackageReference Include="BestEx.InRule" Version="5.0.1" />
+    <PackageReference Include="FsCheck" Version="2.14.0" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BestEx.LoanCollector\BestEx.LoanCollector.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/fixtures/dotnet-fs-package-reference-update/expected-tree.json
+++ b/test/fixtures/dotnet-fs-package-reference-update/expected-tree.json
@@ -1,0 +1,55 @@
+{
+  "dependencies": {
+    "BestEx.Framework": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "BestEx.Framework",
+      "version": "4.10.6"
+    },
+    "BestEx.InRule": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "BestEx.InRule",
+      "version": "5.0.1"
+    },
+    "FsCheck": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "FsCheck",
+      "version": "2.14.0"
+    },
+    "FsCheck.Xunit": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "FsCheck.Xunit",
+      "version": "2.14.0"
+    },
+    "Microsoft.NET.Test.Sdk": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.NET.Test.Sdk",
+      "version": "16.0.1"
+    },
+    "Moq": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Moq",
+      "version": "4.10.1"
+    },
+    "xunit": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "xunit",
+      "version": "2.4.1"
+    },
+    "xunit.runner.visualstudio": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "xunit.runner.visualstudio",
+      "version": "2.4.1"
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "",
+  "version": ""
+}

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -39,6 +39,12 @@ test('.Net F# project tree generated as expected', async (t) => {
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
+test('.Net F# project dependencies with PackageReference Update is skipped', async (t) => {
+  const tree = await buildDepTreeFromFiles(`${__dirname}/../fixtures/dotnet-fs-package-reference-update`, 'example.fsproj', false);
+  const expectedTree = load('dotnet-fs-package-reference-update/expected-tree.json');
+  t.deepEqual(expectedTree, tree, 'trees are equal');
+});
+
 test('.Net simple project tree generated as expected', async (t) => {
   const includeDev = false;
   const tree = await buildDepTreeFromFiles(


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Gracefully handle <PackageReference Update="">, we were returning undefined deps
and this fails import.

Also added to support for multi-groups, <ItemGroups> can be defined many times and
according to the docs it is all the same together or separately.

We were only grabbing the first group.
https://docs.microsoft.com/en-us/dotnet/core/tools/dependencies


#### Any background context you want to provide?
`<PackageReference Update>` syntax was not safely handled.


BST-879