### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/xml2js": "0.4.3",
     "lodash": "^4.17.11",
     "source-map-support": "^0.5.7",
-    "tslib": "^1.9.3",
+    "tslib": "^1.10.0",
     "xml2js": "0.4.19"
   },
   "devDependencies": {
@@ -38,6 +38,6 @@
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
-    "typescript": "3.0.1"
+    "typescript": "3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
-        "lib": ["es5", "es2015.promise"],
+        "target": "es2015",
+        "lib": ["es2015"],
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
