### PR TITLE
Feat: use props map when resolving

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,9 +67,10 @@ async function buildDepTreeFromPackagesConfig(
 
 async function buildDepTreeFromProjectFile(
     manifestFileContents: string,
-    includeDev = false): Promise<PkgTree> {
+    includeDev = false,
+    propsMap: PropsLookup = {}): Promise<PkgTree> {
   const manifestFile: any = await parseXmlFile(manifestFileContents);
-  return getDependencyTreeFromProjectFile(manifestFile, includeDev);
+  return getDependencyTreeFromProjectFile(manifestFile, includeDev, propsMap);
 }
 
 function buildDepTreeFromFiles(

--- a/test/fixtures/dotnet-no-packagereference/Packages.props
+++ b/test/fixtures/dotnet-no-packagereference/Packages.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <codeGenerationVersion>1.0.3</codeGenerationVersion>
+  </PropertyGroup>
+</Project>

--- a/test/fixtures/dotnet-no-packagereference/project.csproj
+++ b/test/fixtures/dotnet-no-packagereference/project.csproj
@@ -35,6 +35,6 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.3" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.3" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="$(codeGenerationVersion)" />
   </ItemGroup>
 </Project>

--- a/test/fixtures/dotnet-variables-resolved/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
+++ b/test/fixtures/dotnet-variables-resolved/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
@@ -29,8 +29,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </AdditionalFiles>
   </ItemGroup>
-  <PropertyGroup>
-    <XunitVersion>1.2.3</XunitVersion>
-    <StyleCopVersion>3.4.5</StyleCopVersion>
-  </PropertyGroup>
 </Project>

--- a/test/lib/variables.test.ts
+++ b/test/lib/variables.test.ts
@@ -5,7 +5,7 @@
 // tslint:disable:object-literal-key-quotes
 import { test } from 'tap';
 import * as fs from 'fs';
-import { buildDepTreeFromProjectFile } from '../../lib';
+import { buildDepTreeFromProjectFile, extractProps } from '../../lib';
 
 /*
 ****** csproj ******
@@ -18,18 +18,26 @@ test('.Net C# project with variable is parsed', async (t) => {
   t.equal(depTree.dependenciesWithUnknownVersions!.length, 4);
 });
 
-test('.Net C# project with variable is parsed and versions resolved', async (t) => {
-  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-variables-resolved/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj`, 'utf-8');
-  const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
+test('.Net C# project with variables is parsed fully when props are read too', async (t) => {
+  const propsFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-with-props/Packages.props`, 'utf-8');
+  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-with-props/example.fsproj`, 'utf-8');
+  const props = await extractProps(propsFileContents);
+
+  const depTree = await buildDepTreeFromProjectFile(manifestFileContents, false, props);
   t.ok(depTree);
-  t.equal(depTree.dependenciesWithUnknownVersions!.length, 2);
-  t.equal(Object.keys(depTree.dependencies)!.length, 2, 'two deps resolved');
+  t.notOk(depTree.dependenciesWithUnknownVersions);
   t.deepEqual(depTree.dependencies, {
+    'Microsoft.NET.Test.Sdk': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'Microsoft.NET.Test.Sdk',
+      'version': '3.3.*',
+    },
     'StyleCop.Analyzers': {
       'depType': 'prod',
       'dependencies': {},
       'name': 'StyleCop.Analyzers',
-      'version': '3.4.5',
+      'version': '1.1.0',
     },
     'xunit': {
       'depType': 'prod',
@@ -37,5 +45,47 @@ test('.Net C# project with variable is parsed and versions resolved', async (t) 
       'name': 'xunit',
       'version': '1.2.3',
     },
-  }, 'two deps resolved');
+    'xunit.runner.visualstudio': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'xunit.runner.visualstudio',
+      'version': '1.1.1-beta*',
+    },
+  }, 'depTree as expected full resolved');
+});
+
+test('.Net oldstyle project with variable is parsed and versions resolved', async (t) => {
+  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-no-packagereference/project.csproj`, 'utf-8');
+  const propsFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-no-packagereference/Packages.props`, 'utf-8');
+  const props = await extractProps(propsFileContents);
+  const depTree = await buildDepTreeFromProjectFile(manifestFileContents, false, props);
+
+  t.ok(depTree);
+  t.equal(depTree.dependenciesWithUnknownVersions!.length, 7, '7 deps with no versions specified');
+  t.deepEqual(depTree.dependencies, {
+    'Newtonsoft.Json': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'Newtonsoft.Json',
+      'version': '10.0.0.0',
+    },
+    'Orleans': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'Orleans',
+      'version': '1.4.0.0',
+    },
+    'System.Console': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'System.Console',
+      'version': '4.0.0.0',
+    },
+    'nunit.framework': {
+      'depType': 'prod',
+      'dependencies': {},
+      'name': 'nunit.framework',
+      'version': '3.8.1.0',
+    },
+    }, 'deps resolved');
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- resolve trees in full when variables are mapped from `props` files and used as a lookup map