### PR TITLE
feat: patch vulnerable lodash using @snyk/lodash

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as _ from 'lodash';
+import * as _ from '@snyk/lodash';
 
 import {PkgTree, DepType, parseXmlFile,
   getDependencyTreeFromPackagesConfig, getDependencyTreeFromProjectJson,

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,5 +1,5 @@
 import * as parseXML from 'xml2js';
-import * as _ from 'lodash';
+import * as _ from '@snyk/lodash';
 import {InvalidUserInputError} from '../errors';
 
 export interface PkgTree {

--- a/lib/parsers/project-assets-json-parser.ts
+++ b/lib/parsers/project-assets-json-parser.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from '@snyk/lodash';
 
 export interface PkgTree {
   name: string;

--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
     "@types/xml2js": "0.4.5",
-    "lodash": "^4.17.11",
+    "@snyk/lodash": "4.17.15-patch",
     "source-map-support": "^0.5.7",
     "tslib": "^1.10.0",
     "xml2js": "0.4.23"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.116",
     "@types/node": "^4.0.47",
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Use forked non-vulnerable `@snyk/lodash` instead of `lodash`

