### PR TITLE
feat: @types is not a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   ],
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
-    "@types/xml2js": "0.4.5",
     "@snyk/lodash": "4.17.15-patch",
     "source-map-support": "^0.5.7",
     "tslib": "^1.10.0",
     "xml2js": "0.4.23"
   },
   "devDependencies": {
-    "@types/node": "^4.0.47",
+    "@types/node": "^6.0.47",
+    "@types/xml2js": "0.4.5",
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",


### PR DESCRIPTION
#### What does this PR do?

`@types` packages are only needed at compile time. `typescript` is a `devDependency`, so I'm reasonably sure we're not compiling with only prod deps installed, so this can definitely be a `devDependency`.

Aiming to reduce bundle size for `snyk/snyk`.