### PR TITLE
fix: lodash 'dot' packages, where necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "12"
   - "10"
   - "8"
-  - "6"
 cache: npm
 script:
   - "npm run lint"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ environment:
     - nodejs_version: "12"
     - nodejs_version: "10"
     - nodejs_version: "8"
-    - nodejs_version: "6"
 
 matrix:
   fast_finish: true

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,6 @@
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as _ from '@snyk/lodash';
 
 import {PkgTree, DepType, parseXmlFile,
   getDependencyTreeFromPackagesConfig, getDependencyTreeFromProjectJson,
@@ -89,7 +88,7 @@ function buildDepTreeFromFiles(
   const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
   const manifestFileExtension = path.extname(manifestFileFullPath);
 
-  if (_.includes(PROJ_FILE_EXTENSIONS, manifestFileExtension)) {
+  if (PROJ_FILE_EXTENSIONS.includes(manifestFileExtension)) {
     return buildDepTreeFromProjectFile(manifestFileContents, includeDev);
   } else if (manifestFilePath.endsWith('packages.config')) {
     return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev);
@@ -157,8 +156,8 @@ async function containsPackageReference(manifestFileContents: string) {
 
   const manifestFile: any = await parseXmlFile(manifestFileContents);
 
-  const projectItems = manifestFile?.Project?.ItemGroup ?? [];
-  const referenceIndex = _.findIndex(projectItems, (itemGroup) => _.has(itemGroup, 'PackageReference'));
+  const projectItems: any[] = manifestFile?.Project?.ItemGroup ?? [];
+  const referenceIndex = projectItems.findIndex((itemGroup) => 'PackageReference' in itemGroup);
 
   return referenceIndex !== -1;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,11 +91,11 @@ function buildDepTreeFromFiles(
 
   if (_.includes(PROJ_FILE_EXTENSIONS, manifestFileExtension)) {
     return buildDepTreeFromProjectFile(manifestFileContents, includeDev);
-  } else if (_.endsWith(manifestFilePath, 'packages.config')) {
+  } else if (manifestFilePath.endsWith('packages.config')) {
     return buildDepTreeFromPackagesConfig(manifestFileContents, includeDev);
-  } else if (_.endsWith(manifestFilePath, 'project.json')) {
+  } else if (manifestFilePath.endsWith('project.json')) {
     return buildDepTreeFromProjectJson(manifestFileContents, includeDev);
-  } else if (_.endsWith(manifestFilePath, 'project.assets.json')) {
+  } else if (manifestFilePath.endsWith('project.assets.json')) {
     return buildDepTreeFromProjectAssetsJson(manifestFileContents, targetFramework);
   } else {
     throw new Error(`Unsupported file ${manifestFilePath}, Please provide ` +
@@ -119,13 +119,13 @@ function extractTargetFrameworksFromFiles(
   const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
   const manifestFileExtension = path.extname(manifestFileFullPath);
 
-  if (_.includes(PROJ_FILE_EXTENSIONS, manifestFileExtension)) {
+  if (PROJ_FILE_EXTENSIONS.includes(manifestFileExtension)) {
     return extractTargetFrameworksFromProjectFile(manifestFileContents);
-  } else if (_.endsWith(manifestFilePath, 'packages.config')) {
+  } else if (manifestFilePath.endsWith('packages.config')) {
     return extractTargetFrameworksFromProjectConfig(manifestFileContents);
-  } else if (_.endsWith(manifestFilePath, 'project.json')) {
+  } else if (manifestFilePath.endsWith('project.json')) {
     return extractTargetFrameworksFromProjectJson(manifestFileContents);
-  } else if (_.endsWith(manifestFilePath, 'project.assets.json')) {
+  } else if (manifestFilePath.endsWith('project.assets.json')) {
     return extractTargetFrameworksFromProjectAssetsJson(manifestFileContents);
   } else {
     throw new Error(`Unsupported file ${manifestFilePath}, Please provide ` +

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -155,9 +155,9 @@ async function extractTargetFrameworksFromProjectConfig(
 
 async function containsPackageReference(manifestFileContents: string) {
 
-  const manifestFile: object = await parseXmlFile(manifestFileContents);
+  const manifestFile: any = await parseXmlFile(manifestFileContents);
 
-  const projectItems = _.get(manifestFile, 'Project.ItemGroup', []);
+  const projectItems = manifestFile?.Project?.ItemGroup ?? [];
   const referenceIndex = _.findIndex(projectItems, (itemGroup) => _.has(itemGroup, 'PackageReference'));
 
   return referenceIndex !== -1;

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,5 +1,7 @@
 import * as parseXML from 'xml2js';
-import * as _ from '@snyk/lodash';
+import * as _isEmpty from 'lodash.isempty';
+import * as _set from 'lodash.set';
+import * as _uniq from 'lodash.uniq';
 import {InvalidUserInputError} from '../errors';
 
 export interface PkgTree {
@@ -297,7 +299,7 @@ function buildSubTreeFromReferenceInclude(
   dep, isDev: boolean, manifestFile, targetFrameworks: string[], propsMap: PropsLookup):
   PkgTree | DependencyWithoutVersion {
   const version = extractDependencyVersion(dep, manifestFile, propsMap) || '';
-  if (!_.isEmpty(version)) {
+  if (!_isEmpty(version)) {
     const depSubTree: PkgTree = {
       depType: isDev ? DepType.dev : DepType.prod,
       dependencies: {},
@@ -324,7 +326,7 @@ function buildSubTreeFromPackageReference(
   PkgTree | DependencyWithoutVersion {
 
   const version = extractDependencyVersion(dep, manifestFile, propsMap) || '';
-  if (!_.isEmpty(version)) {
+  if (!_isEmpty(version)) {
 
     const depSubTree: PkgTree = {
       depType: isDev ? DepType.dev : DepType.prod,
@@ -399,7 +401,7 @@ export function getPropertiesMap(propsContents: any): PropsLookup {
 
   for (const group of projectPropertyGroup) {
     for (const key of Object.keys(group)) {
-      _.set(props, key, group[key][0]);
+      _set(props, key, group[key][0]);
     }
   }
   return props;
@@ -419,7 +421,7 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
         || 'TargetFrameworkVersion' in propertyGroup;
       }) || {};
 
-  if (_.isEmpty(propertyList)) {
+  if (_isEmpty(propertyList)) {
     return targetFrameworksResult;
   }
   // TargetFrameworks is expected to be a list ; separated
@@ -439,7 +441,7 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
     targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFramework];
   }
 
-  return _.uniq(targetFrameworksResult);
+  return _uniq(targetFrameworksResult);
 }
 
 export function getTargetFrameworksFromProjectConfig(manifestFile) {

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -203,7 +203,7 @@ function processItemGroupForPackageReference(
   includeDev: boolean,
   dependenciesResult,
   propsMap: PropsLookup) {
-  const targetFrameworks: string[] = packageList?.["$"]?.Condition ?? false ?
+  const targetFrameworks: string[] = packageList?.$?.Condition ?? false ?
     getConditionalFrameworks(packageList.$.Condition) : [];
 
   for (const dep of packageList.PackageReference) {
@@ -256,7 +256,7 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
 
 function processItemGroupForReferenceInclude(
   packageList, manifestFile,  includeDev, dependenciesResult, propsMap) {
-  const targetFrameworks: string[] = packageList?.["$"]?.Condition ?? false ?
+  const targetFrameworks: string[] = packageList?.$?.Condition ?? false ?
     getConditionalFrameworks(packageList.$.Condition) : [];
 
   for (const item of packageList.Reference) {
@@ -348,7 +348,7 @@ function buildSubTreeFromPackageReference(
 
 function extractDependencyVersion(dep, manifestFile, propsMap): string | null {
   const VARS_MATCHER = /^\$\((.*?)\)/;
-  let version  = dep?.["$"]?.Version || dep?.Version;
+  let version  = dep?.$?.Version || dep?.Version;
   if (Array.isArray(version)) {
     version = version[0];
   }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -137,8 +137,8 @@ export async function getDependencyTreeFromProjectFile(
   propsMap: PropsLookup = {}): Promise<PkgTree> {
   const nameProperty = (manifestFile?.Project?.PropertyGroup ?? [])
     .find((propertyGroup) => {
-      return _.has(propertyGroup, 'PackageId')
-      || _.has(propertyGroup, 'AssemblyName');
+      return 'PackageId' in propertyGroup
+      || 'AssemblyName' in propertyGroup;
     }) || {};
 
   const name = (nameProperty.PackageId?.[0])
@@ -181,7 +181,7 @@ async function getDependenciesFromPackageReference(
     hasDevDependencies: false,
   };
   const packageGroups = (manifestFile?.Project?.ItemGroup ?? [])
-    .filter((itemGroup) => _.has(itemGroup, 'PackageReference'));
+    .filter((itemGroup) => 'PackageReference' in itemGroup);
 
   if (!packageGroups.length) {
     return dependenciesResult;
@@ -239,7 +239,7 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
 
   const referenceIncludeList =
   (manifestFile?.Project?.ItemGroup ?? [])
-  .find((itemGroup) => _.has(itemGroup, 'Reference'));
+  .find((itemGroup) => 'Reference' in itemGroup);
 
   if (!referenceIncludeList) {
     return referenceIncludeResult;
@@ -414,9 +414,9 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   }
   const propertyList = projectPropertyGroup
     .find((propertyGroup) => {
-        return _.has(propertyGroup, 'TargetFramework')
-        || _.has(propertyGroup, 'TargetFrameworks')
-        || _.has(propertyGroup, 'TargetFrameworkVersion');
+        return 'TargetFramework' in propertyGroup
+        || 'TargetFrameworks' in propertyGroup
+        || 'TargetFrameworkVersion' in propertyGroup;
       }) || {};
 
   if (_.isEmpty(propertyList)) {
@@ -452,7 +452,7 @@ export function getTargetFrameworksFromProjectConfig(manifestFile) {
       continue;
     }
 
-    if (!_.includes(targetFrameworksResult, targetFramework)) {
+    if (!targetFrameworksResult.includes(targetFramework)) {
       targetFrameworksResult.push(targetFramework);
     }
   }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -101,7 +101,7 @@ export async function getDependencyTreeFromPackagesConfig(
     version: '',
   };
 
-  const packageList = _.get(manifestFile, 'packages.package', []);
+  const packageList = manifestFile?.packages?.package ?? [];
 
   for (const dep of packageList) {
     const depName = dep.$.id;
@@ -135,14 +135,14 @@ export async function getDependencyTreeFromProjectFile(
   manifestFile,
   includeDev: boolean = false,
   propsMap: PropsLookup = {}): Promise<PkgTree> {
-  const nameProperty = _.get(manifestFile, 'Project.PropertyGroup', [])
+  const nameProperty = (manifestFile?.Project?.PropertyGroup ?? [])
     .find((propertyGroup) => {
       return _.has(propertyGroup, 'PackageId')
       || _.has(propertyGroup, 'AssemblyName');
     }) || {};
 
-  const name = (nameProperty.PackageId && nameProperty.PackageId[0])
-    || (nameProperty.AssemblyName && nameProperty.AssemblyName[0])
+  const name = (nameProperty.PackageId?.[0])
+    || (nameProperty.AssemblyName?.[0])
     || '';
 
   const packageReferenceDeps =
@@ -180,7 +180,7 @@ async function getDependenciesFromPackageReference(
     dependencies: {},
     hasDevDependencies: false,
   };
-  const packageGroups = _.get(manifestFile, 'Project.ItemGroup', [])
+  const packageGroups = (manifestFile?.Project?.ItemGroup ?? [])
     .filter((itemGroup) => _.has(itemGroup, 'PackageReference'));
 
   if (!packageGroups.length) {
@@ -201,7 +201,7 @@ function processItemGroupForPackageReference(
   includeDev: boolean,
   dependenciesResult,
   propsMap: PropsLookup) {
-  const targetFrameworks: string[] = _.get(packageList, '$.Condition', false) ?
+  const targetFrameworks: string[] = packageList?.["$"]?.Condition ?? false ?
     getConditionalFrameworks(packageList.$.Condition) : [];
 
   for (const dep of packageList.PackageReference) {
@@ -238,7 +238,7 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
   };
 
   const referenceIncludeList =
-  _.get(manifestFile, 'Project.ItemGroup', [])
+  (manifestFile?.Project?.ItemGroup ?? [])
   .find((itemGroup) => _.has(itemGroup, 'Reference'));
 
   if (!referenceIncludeList) {
@@ -254,7 +254,7 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
 
 function processItemGroupForReferenceInclude(
   packageList, manifestFile,  includeDev, dependenciesResult, propsMap) {
-  const targetFrameworks: string[] = _.get(packageList, '$.Condition', false) ?
+  const targetFrameworks: string[] = packageList?.["$"]?.Condition ?? false ?
     getConditionalFrameworks(packageList.$.Condition) : [];
 
   for (const item of packageList.Reference) {
@@ -346,7 +346,7 @@ function buildSubTreeFromPackageReference(
 
 function extractDependencyVersion(dep, manifestFile, propsMap): string | null {
   const VARS_MATCHER = /^\$\((.*?)\)/;
-  let version  = _.get(dep, '$.Version') || _.get(dep, 'Version');
+  let version  = dep?.["$"]?.Version || dep?.Version;
   if (Array.isArray(version)) {
     version = version[0];
   }
@@ -357,7 +357,7 @@ function extractDependencyVersion(dep, manifestFile, propsMap): string | null {
   // version is a variable, extract it from manifest or props lookup
   const propertyName = variableVersion[1];
   const propertyMap = {...propsMap, ...getPropertiesMap(manifestFile)};
-  return _.get(propertyMap, propertyName, null);
+  return propertyMap?.[propertyName] ?? null;
 }
 
 function getConditionalFrameworks(condition: string) {
@@ -390,8 +390,8 @@ export interface PropsLookup {
   [name: string]: string;
 }
 
-export function getPropertiesMap(propsContents: object): PropsLookup {
-  const projectPropertyGroup = _.get(propsContents, 'Project.PropertyGroup', []);
+export function getPropertiesMap(propsContents: any): PropsLookup {
+  const projectPropertyGroup = propsContents?.Project?.PropertyGroup ?? [];
   const props: PropsLookup = {};
   if (!projectPropertyGroup.length) {
     return props;
@@ -407,7 +407,7 @@ export function getPropertiesMap(propsContents: object): PropsLookup {
 
 export function getTargetFrameworksFromProjectFile(manifestFile) {
   let targetFrameworksResult: string[] = [];
-  const projectPropertyGroup = _.get(manifestFile, 'Project.PropertyGroup', []);
+  const projectPropertyGroup = manifestFile?.Project?.PropertyGroup ?? [];
 
   if (!projectPropertyGroup ) {
     return targetFrameworksResult;
@@ -444,7 +444,7 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
 
 export function getTargetFrameworksFromProjectConfig(manifestFile) {
   const targetFrameworksResult: string[] = [];
-  const packages = _.get(manifestFile, 'packages.package', []);
+  const packages = manifestFile?.packages?.package ?? [];
 
   for (const item of packages) {
     const targetFramework = item.$.targetFramework;
@@ -461,9 +461,9 @@ export function getTargetFrameworksFromProjectConfig(manifestFile) {
 }
 
 export function getTargetFrameworksFromProjectJson(manifestFile) {
-  return Object.keys(_.get(manifestFile, 'frameworks', {}));
+  return Object.keys(manifestFile?.frameworks ?? {});
 }
 
 export function getTargetFrameworksFromProjectAssetsJson(manifestFile) {
-  return Object.keys(_.get(manifestFile, 'targets', {}));
+  return Object.keys(manifestFile?.targets ?? {});
 }

--- a/lib/parsers/project-assets-json-parser.ts
+++ b/lib/parsers/project-assets-json-parser.ts
@@ -1,5 +1,3 @@
-import * as _ from '@snyk/lodash';
-
 export interface PkgTree {
   name: string;
   version: string;
@@ -29,11 +27,11 @@ export interface ProjectAssetsJsonManifest {
 }
 
 function getProjectNameForProjectAssetsJson(manifestFile) {
-  return _.get(manifestFile, ['project', 'restore', 'projectName'], {});
+  return manifestFile?.project?.restore?.projectName ?? {};
 }
 
 function getProjectVersionForProjectAssetsJson(manifestFile) {
-  return _.get(manifestFile, ['project', 'version'], {});
+  return manifestFile?.project?.version ?? {};
 }
 
 function buildPackageTree(name, version) {
@@ -57,12 +55,12 @@ export function getDependencyTreeFromProjectAssetsJson(
   const projectVersion = getProjectVersionForProjectAssetsJson(manifestFile);
   const depTree = buildPackageTree(projectName, projectVersion);
 
-  const topLevelDeps = Object.keys(_.get(manifestFile, ['targets', targetFrameWork], {}));
+  const topLevelDeps = Object.keys(manifestFile?.targets?.[targetFrameWork] ?? {});
   for (const topLevelDep of topLevelDeps) {
     const [topLevelDepName, topLevelDepVersion] = topLevelDep.split('/');
     const topLevelDepTree = buildPackageTree(topLevelDepName, topLevelDepVersion);
 
-    const transitiveDeps = _.get(manifestFile, ['targets', targetFrameWork, topLevelDep, 'dependencies'], {});
+    const transitiveDeps = manifestFile?.targets?.[targetFrameWork]?.[topLevelDep]?.dependencies ?? {};
     for (const transitiveDep of Object.keys(transitiveDeps)) {
       const transitiveDepVersion = transitiveDeps[transitiveDep];
       const transitiveDepTree = buildPackageTree(transitiveDep, transitiveDepVersion);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   ],
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
-    "@snyk/lodash": "4.17.15-patch",
+    "lodash.isempty": "^4.4.0",
+    "lodash.set": "^4.3.2",
+    "lodash.uniq": "^4.5.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.10.0",
     "xml2js": "0.4.23"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "files": [
     "bin",
@@ -32,7 +32,7 @@
     "xml2js": "0.4.23"
   },
   "devDependencies": {
-    "@types/node": "^6.0.47",
+    "@types/node": "^8.10.61",
     "@types/xml2js": "0.4.5",
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es2015",
-        "lib": ["es2015"],
+        "target": "es2017",
+        "lib": ["es2017"],
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
#### What does this PR do?

This is a heavy-handed attempt to migrate away from `lodash`, and use language features where possible. It's mostly find/replace.

Moving to `node 8`, is a `BREAKING CHANGE`.