### PR TITLE
fix: correcting a bug that generates a third blank target framework

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -427,7 +427,7 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   // TargetFrameworks is expected to be a list ; separated
   if (propertyList.TargetFrameworks) {
     for (const item of propertyList.TargetFrameworks) {
-      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';')];
+      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';').filter( (x) => !_isEmpty(x))];
     }
   }
   // TargetFrameworkVersion is expected to be a string containing only one item

--- a/test/fixtures/dotnet-multiple-target-frameworks/multi-target.csproj
+++ b/test/fixtures/dotnet-multiple-target-frameworks/multi-target.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net462;</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ProjectGuid>{B026B0BC-F542-4326-B68F-C83E62BCC5F1}</ProjectGuid>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.0.1" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.0.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.100.4" />
+  </ItemGroup>
+
+</Project>

--- a/test/lib/target-frameworks.test.ts
+++ b/test/lib/target-frameworks.test.ts
@@ -40,6 +40,13 @@ test('.Net .csproj dotnet-empty-manifest target framework extracted', async (t) 
   t.deepEqual(targetFrameworks, [], 'targetFramework array is as expected');
 });
 
+test('.Net .csproj multiple target frameworks extracted as expected', async (t) => {
+  const targetFrameworks = await extractTargetFrameworksFromFiles(
+      `${__dirname}/../fixtures/dotnet-multiple-target-frameworks`,
+      'multi-target.csproj');
+  t.deepEqual(targetFrameworks, ['netstandard2.0', 'net462'], 'targetFramework array is as expected');
+});
+
 /*
 ****** fsproj ******
 */


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Due to the way the string split function is working, the string split produces 3 items (['netstandard2.0','net462','']) from this string: <netstandard2.0;net462;> and not two. 

#### Where should the reviewer start?
The Test

#### How should this be manually tested?


#### Any background context you want to provide?
This was reported by a customer 
Note that there will be another PR for the dotnet-deps project once this one is resolved

#### What are the relevant tickets?
https://snyk.zendesk.com/agent/tickets/7939

#### Screenshots


#### Additional questions
