### PR TITLE
feat: access itemGroups in a safer manner

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -157,7 +157,8 @@ async function containsPackageReference(manifestFileContents: string) {
   const manifestFile: any = await parseXmlFile(manifestFileContents);
 
   const projectItems: any[] = manifestFile?.Project?.ItemGroup ?? [];
-  const referenceIndex = projectItems.findIndex((itemGroup) => 'PackageReference' in itemGroup);
+  const referenceIndex = projectItems
+    .findIndex((itemGroup) => typeof itemGroup === 'object' && 'PackageReference' in itemGroup);
 
   return referenceIndex !== -1;
 }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -183,7 +183,7 @@ async function getDependenciesFromPackageReference(
     hasDevDependencies: false,
   };
   const packageGroups = (manifestFile?.Project?.ItemGroup ?? [])
-    .filter((itemGroup) => 'PackageReference' in itemGroup);
+    .filter((itemGroup) => typeof itemGroup === 'object' && 'PackageReference' in itemGroup);
 
   if (!packageGroups.length) {
     return dependenciesResult;
@@ -241,7 +241,7 @@ async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boo
 
   const referenceIncludeList =
   (manifestFile?.Project?.ItemGroup ?? [])
-  .find((itemGroup) => 'Reference' in itemGroup);
+  .find((itemGroup) => typeof itemGroup === 'object' && 'Reference' in itemGroup);
 
   if (!referenceIncludeList) {
     return referenceIncludeResult;

--- a/test/fixtures/dotnet-core-simple-project-empty-item-group/simple-project-empty-item-group.csproj
+++ b/test/fixtures/dotnet-core-simple-project-empty-item-group/simple-project-empty-item-group.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp1.2</TargetFrameworks>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
+    <UserSecretsId>aspnet-simple_project-2905A172-2378-4427-901F-971E0933141A</UserSecretsId>
+    <AssemblyName>Simple-Project-Name</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include=" Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="1.1.5" PrivateAssets="All" />
+    <PackageReference Include="newtonsoft.json" Version="11.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.3" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.3" />
+  </ItemGroup>
+</Project>

--- a/test/lib/package-reference.test.ts
+++ b/test/lib/package-reference.test.ts
@@ -19,6 +19,13 @@ test('Project contains PackageReference as expected even if Reference Include pr
   t.true(hasPackageReference);
 });
 
+test('.Net C# project contains PackageReference with empty item group works as expected', async (t) => {
+  const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-core-simple-project-empty-item-group/simple-project-empty-item-group.csproj`, 'utf-8');
+  const hasPackageReference = await containsPackageReference(manifestFileContents);
+  t.true(hasPackageReference);
+});
+
+
 test('.Net C# project does not contain PackageReference as expected', async (t) => {
   const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-no-packagereference/project.csproj`, 'utf-8');
   const hasPackageReference = await containsPackageReference(manifestFileContents);


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When there are empty <itemGroup> sections, the XML parser returns them as a new line.

This change makes sure that the item groups are safe to access.

https://snyk.zendesk.com/agent/tickets/8356
