### PR TITLE
fix: support attributes in TargetFrameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.log
 package-lock.json
 .nyc_output/
+.idea

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -427,7 +427,7 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   // TargetFrameworks is expected to be a list ; separated
   if (propertyList.TargetFrameworks) {
     for (const item of propertyList.TargetFrameworks) {
-      targetFrameworksResult = [...targetFrameworksResult, ...item.split(';').filter( (x) => !_isEmpty(x))];
+      targetFrameworksResult = [...targetFrameworksResult, ...getTargetFrameworks(item)];
     }
   }
   // TargetFrameworkVersion is expected to be a string containing only one item
@@ -442,6 +442,13 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   }
 
   return _uniq(targetFrameworksResult);
+}
+
+function getTargetFrameworks(item: string | any) {
+  if (typeof item === 'object' && item.hasOwnProperty('_')) {
+    item = item._;
+  }
+  return item.split(';').filter((x) => !_isEmpty(x));
 }
 
 export function getTargetFrameworksFromProjectConfig(manifestFile) {

--- a/test/fixtures/dotnet-core-simple-project-complex-target-frameworks/expected-tree.json
+++ b/test/fixtures/dotnet-core-simple-project-complex-target-frameworks/expected-tree.json
@@ -1,0 +1,124 @@
+{
+  "dependencies": {
+    "Microsoft.AspNetCore": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore",
+      "version": "1.1.7"
+    },
+    "Microsoft.AspNetCore.Authentication.Cookies": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Authentication.Cookies",
+      "version": "1.1.3"
+    },
+    "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore",
+      "version": "1.1.6"
+    },
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
+      "version": "1.1.6"
+    },
+    "Microsoft.AspNetCore.Mvc": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.Mvc",
+      "version": "1.1.8"
+    },
+    "Microsoft.AspNetCore.StaticFiles": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.AspNetCore.StaticFiles",
+      "version": "1.1.3"
+    },
+    "Microsoft.EntityFrameworkCore.Design": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.EntityFrameworkCore.Design",
+      "version": "1.1.6"
+    },
+    "Microsoft.EntityFrameworkCore.Sqlite": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.EntityFrameworkCore.Sqlite",
+      "version": "1.1.6"
+    },
+    "Microsoft.EntityFrameworkCore.Sqlite.Design": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.EntityFrameworkCore.Sqlite.Design",
+      "version": "1.1.6"
+    },
+    "Microsoft.EntityFrameworkCore.Tools": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.EntityFrameworkCore.Tools",
+      "version": "1.1.6"
+    },
+    "Microsoft.Extensions.Configuration.UserSecrets": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.Extensions.Configuration.UserSecrets",
+      "version": "1.1.2"
+    },
+    "Microsoft.Extensions.Logging.Debug": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.Extensions.Logging.Debug",
+      "version": "1.1.2"
+    },
+    "Microsoft.VisualStudio.Web.CodeGeneration.Design": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Microsoft.VisualStudio.Web.CodeGeneration.Design",
+      "version": "1.1.5"
+    },
+    "newtonsoft.json": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "newtonsoft.json",
+      "version": "11.0.2"
+    },
+    "System.Console": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Console",
+      "version": "4.0.0.0"
+    },
+    "Newtonsoft.Json": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Newtonsoft.Json",
+      "version": "10.0.0.0"
+    },
+    "nunit.framework": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "nunit.framework",
+      "version": "3.8.1.0"
+    },
+    "Orleans": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "Orleans",
+      "version": "1.4.0.0"
+    }
+  },
+  "dependenciesWithUnknownVersions": [
+    "Microsoft.CSharp",
+    "System.Web.DynamicData",
+    "System.Web.Entity",
+    "System.Web.ApplicationServices",
+    "System.ComponentModel.DataAnnotations",
+    "System",
+    "Microsoft.Web.Infrastructure"
+  ],
+  "hasDevDependencies": false,
+  "name": "Simple-Project-Name",
+  "version": ""
+}

--- a/test/fixtures/dotnet-core-simple-project-complex-target-frameworks/simple-project.csproj
+++ b/test/fixtures/dotnet-core-simple-project-complex-target-frameworks/simple-project.csproj
@@ -1,0 +1,56 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netcoreapp1.1;netcoreapp1.2</TargetFrameworks>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
+    <UserSecretsId>aspnet-simple_project-2905A172-2378-4427-901F-971E0933141A</UserSecretsId>
+    <AssemblyName>Simple-Project-Name</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include=" Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="1.1.5" PrivateAssets="All" />
+    <PackageReference Include="newtonsoft.json" Version="11.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.3" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.3" />
+  </ItemGroup>
+</Project>

--- a/test/lib/target-frameworks.test.ts
+++ b/test/lib/target-frameworks.test.ts
@@ -33,6 +33,13 @@ test('.Net .csproj simple project target framework extracted as expected', async
   t.deepEqual(targetFrameworks, ['netcoreapp1.1', 'netcoreapp1.2'], 'targetFramework array is as expected');
 });
 
+test('.Net .csproj simple project target framework with attributes extracted as expected', async (t) => {
+  const targetFrameworks = await extractTargetFrameworksFromFiles(
+    `${__dirname}/../fixtures/dotnet-core-simple-project-complex-target-frameworks`,
+    'simple-project.csproj');
+  t.deepEqual(targetFrameworks, ['netcoreapp1.1', 'netcoreapp1.2'], 'targetFramework array is as expected');
+});
+
 test('.Net .csproj dotnet-empty-manifest target framework extracted', async (t) => {
   const targetFrameworks = await extractTargetFrameworksFromFiles(
     `${__dirname}/../fixtures/dotnet-empty-manifest`,


### PR DESCRIPTION
Today we don't support attributes on the TargetFrameworks property in .csproj files
This change adds this support

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team