### PR TITLE
fixed import error when tag is empty for dotnet projects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/test/**/*.spec.ts"],
+};

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -138,6 +138,7 @@ export async function getDependencyTreeFromProjectFile(
   includeDev: boolean = false,
   propsMap: PropsLookup = {}): Promise<PkgTree> {
   const nameProperty = (manifestFile?.Project?.PropertyGroup ?? [])
+  .filter((propertyGroup) => typeof propertyGroup !== 'string')
     .find((propertyGroup) => {
       return 'PackageId' in propertyGroup
       || 'AssemblyName' in propertyGroup;
@@ -173,7 +174,7 @@ export async function getDependencyTreeFromProjectFile(
   return depTree;
 }
 
-async function getDependenciesFromPackageReference(
+export async function getDependenciesFromPackageReference(
   manifestFile,
   includeDev: boolean = false,
   propsMap: PropsLookup):
@@ -231,7 +232,8 @@ function processItemGroupForPackageReference(
 }
 
 // TODO: almost same as getDependenciesFromPackageReference
-async function getDependenciesFromReferenceInclude(manifestFile, includeDev: boolean = false, propsMap: PropsLookup):
+export async function getDependenciesFromReferenceInclude(
+  manifestFile, includeDev: boolean = false, propsMap: PropsLookup):
   Promise <DependenciesDiscoveryResult> {
 
   let referenceIncludeResult: DependenciesDiscoveryResult = {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "description": "Generate a dep tree given a collection of manifests",
   "main": "dist/index.js",
   "scripts": {
-    "test": "npm run lint && npm run unit-test",
-    "unit-test": "npm run build && tap test/lib -Rspec --timeout=300",
+    "test": "npm run lint && npm run test:tap && npm run test:jest",
+    "test:tap": "npm run build && tap test/lib/**/*.test.ts -Rspec --timeout=300",
+    "test:jest": "jest",
     "lint": "tslint -p tsconfig.json",
     "build": "tsc",
     "build-watch": "tsc -w",
@@ -36,6 +37,9 @@
   "devDependencies": {
     "@types/node": "^8.10.61",
     "@types/xml2js": "0.4.5",
+    "@types/jest": "^23.3.2",
+    "jest": "23.6.0",
+    "ts-jest": "^23.10.1",
     "tap": "^14.10.7",
     "tslint": "5.11.0",
     "typescript": "3.7.3"

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -1,0 +1,102 @@
+import * as parsers from '../../lib/parsers/index';
+
+describe('Tests for property group tag', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('should not fail when property group tag is empty', async () => {
+    jest
+      .spyOn(parsers, 'getDependenciesFromReferenceInclude')
+      .mockImplementation(() =>
+        Promise.resolve({ dependencies: {}, hasDevDependencies: false })
+      );
+    jest
+      .spyOn(parsers, 'getDependenciesFromPackageReference')
+      .mockImplementation(() =>
+        Promise.resolve({
+          dependencies: {
+            foo: {
+              name: 'foo',
+              version: '1.0.0',
+              dependencies: {},
+            },
+          },
+          hasDevDependencies: false,
+        })
+      );
+
+    const propertyGroup = [
+      {
+        RuntimeIdentifiers: ['win-x64;linux-x64'],
+        TargetFramework: ['netcoreapp3.1'],
+        AzureFunctionsVersion: ['v3'],
+        UserSecretsId: ['d7b31cfb-0edc-44d5-8646-ca9de9592e1e'],
+        CodeAnalysisRuleSet: ['../../Settings.StyleCop'],
+        TreatWarningsAsErrors: ['false'],
+        LangVersion: ['latest'],
+        Nullable: ['enable'],
+        ProjectGuid: ['{37e13009-759c-4c94-8aa2-91a9a8da7a13}'],
+      },
+      '\n\n  ',
+    ];
+
+    const mockManifestFile = {
+      Project: {
+        PropertyGroup: propertyGroup,
+      },
+    };
+
+    expect(
+      parsers.getDependencyTreeFromProjectFile(mockManifestFile)
+    ).toBeTruthy();
+  });
+
+  it('should not fail when property group tag is not empty ', async () => {
+    jest
+      .spyOn(parsers, 'getDependenciesFromReferenceInclude')
+      .mockImplementation(() =>
+        Promise.resolve({ dependencies: {}, hasDevDependencies: false })
+      );
+    jest
+      .spyOn(parsers, 'getDependenciesFromPackageReference')
+      .mockImplementation(() =>
+        Promise.resolve({
+          dependencies: {
+            foo: {
+              name: 'foo',
+              version: '1.0.0',
+              dependencies: {},
+            },
+          },
+          hasDevDependencies: false,
+        })
+      );
+
+    const propertyGroup = [
+      {
+        RuntimeIdentifiers: [ 'win-x64;linux-x64' ],
+        TargetFramework: [ 'netcoreapp3.1' ],
+        AzureFunctionsVersion: [ 'v3' ],
+        UserSecretsId: [ 'd7b31cfb-0edc-44d5-8646-ca9de9592e1e' ],
+        CodeAnalysisRuleSet: [ '../../Settings.StyleCop' ],
+        TreatWarningsAsErrors: [ 'false' ],
+        LangVersion: [ 'latest' ],
+        Nullable: [ 'enable' ],
+        ProjectGuid: [ '{37e13009-759c-4c94-8aa2-91a9a8da7a13}' ]
+      },
+      {
+        RuntimeIdentifiers: [ 'win-x64;linux-x64' ],
+        TargetFramework: [ 'netcoreapp3.1' ]
+      }
+    ];
+
+    const mockManifestFile = {
+      Project: {
+        PropertyGroup: propertyGroup,
+      },
+    };
+
+    expect(
+      parsers.getDependencyTreeFromProjectFile(mockManifestFile)
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This pr ignores the empty PropertyGroup tags when importing the project instead of throwing an error and stopping you from importing the project into Snyk.


#### How should this be manually tested?
Import a project with empty PropertyGroup tag;
<PropertyGroup>
 </PropertyGroup>
If this is imported then it should not fail like it did previously when this was empty. 


#### Any background context you want to provide?
Previously the following error would appear; 

<img width="1472" alt="Screenshot 2021-08-20 at 12 21 39" src="https://user-images.githubusercontent.com/78368516/130226041-4f475494-cdc9-4733-a155-3ada5cef477b.png">


#### What are the relevant tickets?
https://snyksec.atlassian.net/secure/RapidBoard.jspa?rapidView=248&projectKey=LOKI&modal=detail&selectedIssue=LOKI-114
