### PR TITLE
feat: resolve missing and unknown versions

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -2,7 +2,7 @@ import * as parseXML from 'xml2js';
 import * as _isEmpty from 'lodash.isempty';
 import * as _set from 'lodash.set';
 import * as _uniq from 'lodash.uniq';
-import {InvalidUserInputError} from '../errors';
+import { InvalidUserInputError } from '../errors';
 
 export interface PkgTree {
   name: string;
@@ -14,12 +14,14 @@ export interface PkgTree {
   hasDevDependencies?: boolean;
   cyclic?: boolean;
   targetFrameworks?: string[];
+  dependenciesWithInjectedPropVersion?: string[];
   dependenciesWithUnknownVersions?: string[];
 }
 
-export interface DependencyWithoutVersion {
+export interface DependencyUnresolvedVersion {
   name: string;
-  withoutVersion: true;
+  unknownVersion: boolean;
+  injectedVersion: boolean;
 }
 
 export enum DepType {
@@ -38,6 +40,8 @@ export interface ReferenceInclude {
 export interface DependenciesDiscoveryResult {
   dependencies: { [dep: string]: PkgTree };
   hasDevDependencies: boolean;
+  // dependency version injected via build property
+  dependenciesWithInjectedPropVersion?: string[];
   dependenciesWithUnknownVersions?: string[];
 }
 
@@ -59,7 +63,10 @@ export interface ProjectJsonManifest {
   };
 }
 
-export function getDependencyTreeFromProjectJson(manifestFile: ProjectJsonManifest, includeDev: boolean = false) {
+export function getDependencyTreeFromProjectJson(
+  manifestFile: ProjectJsonManifest,
+  includeDev: boolean = false,
+) {
   const depTree: PkgTree = {
     dependencies: {},
     hasDevDependencies: false,
@@ -72,13 +79,18 @@ export function getDependencyTreeFromProjectJson(manifestFile: ProjectJsonManife
       continue;
     }
     const depValue = manifestFile.dependencies[depName];
-    const version = (depValue as ProjectJsonManifestDependency).version || depValue;
+    const version =
+      (depValue as ProjectJsonManifestDependency).version || depValue;
     const isDev = (depValue as ProjectJsonManifestDependency).type === 'build';
     depTree.hasDevDependencies = depTree.hasDevDependencies || isDev;
     if (isDev && !includeDev) {
       continue;
     }
-    depTree.dependencies[depName] = buildSubTreeFromProjectJson(depName, version, isDev);
+    depTree.dependencies[depName] = buildSubTreeFromProjectJson(
+      depName,
+      version,
+      isDev,
+    );
   }
   return depTree;
 }
@@ -95,7 +107,9 @@ function buildSubTreeFromProjectJson(name, version, isDev: boolean): PkgTree {
 }
 
 export async function getDependencyTreeFromPackagesConfig(
-  manifestFile, includeDev: boolean = false): Promise<PkgTree> {
+  manifestFile,
+  includeDev: boolean = false,
+): Promise<PkgTree> {
   const depTree: PkgTree = {
     dependencies: {},
     hasDevDependencies: false,
@@ -136,22 +150,28 @@ function buildSubTreeFromPackagesConfig(dep, isDev: boolean): PkgTree {
 export async function getDependencyTreeFromProjectFile(
   manifestFile,
   includeDev: boolean = false,
-  propsMap: PropsLookup = {}): Promise<PkgTree> {
-  const nameProperty = (manifestFile?.Project?.PropertyGroup ?? [])
-  .filter((propertyGroup) => typeof propertyGroup !== 'string')
-    .find((propertyGroup) => {
-      return 'PackageId' in propertyGroup
-      || 'AssemblyName' in propertyGroup;
-    }) || {};
+  propsMap: PropsLookup = {},
+): Promise<PkgTree> {
+  const nameProperty =
+    (manifestFile?.Project?.PropertyGroup ?? [])
+      .filter((propertyGroup) => typeof propertyGroup !== 'string')
+      .find((propertyGroup) => {
+        return 'PackageId' in propertyGroup || 'AssemblyName' in propertyGroup;
+      }) || {};
 
-  const name = (nameProperty.PackageId?.[0])
-    || (nameProperty.AssemblyName?.[0])
-    || '';
+  const name =
+    nameProperty.PackageId?.[0] || nameProperty.AssemblyName?.[0] || '';
 
-  const packageReferenceDeps =
-    await getDependenciesFromPackageReference(manifestFile, includeDev, propsMap);
-  const referenceIncludeDeps =
-    await getDependenciesFromReferenceInclude(manifestFile, includeDev, propsMap);
+  const packageReferenceDeps = await getDependenciesFromPackageReference(
+    manifestFile,
+    includeDev,
+    propsMap,
+  );
+  const referenceIncludeDeps = await getDependenciesFromReferenceInclude(
+    manifestFile,
+    includeDev,
+    propsMap,
+  );
 
   // order matters, the order deps are parsed in needs to be preserved and first seen kept
   // so applying the packageReferenceDeps last to override the second parsed
@@ -160,15 +180,23 @@ export async function getDependencyTreeFromProjectFile(
       ...referenceIncludeDeps.dependencies,
       ...packageReferenceDeps.dependencies,
     },
-    hasDevDependencies: packageReferenceDeps.hasDevDependencies || referenceIncludeDeps.hasDevDependencies,
+    hasDevDependencies:
+      packageReferenceDeps.hasDevDependencies ||
+      referenceIncludeDeps.hasDevDependencies,
     name,
     version: '',
   };
   if (packageReferenceDeps.dependenciesWithUnknownVersions) {
-    depTree.dependenciesWithUnknownVersions = packageReferenceDeps.dependenciesWithUnknownVersions;
+    depTree.dependenciesWithUnknownVersions =
+      packageReferenceDeps.dependenciesWithUnknownVersions;
   }
   if (referenceIncludeDeps.dependenciesWithUnknownVersions) {
-    depTree.dependenciesWithUnknownVersions = referenceIncludeDeps.dependenciesWithUnknownVersions;
+    depTree.dependenciesWithUnknownVersions =
+      referenceIncludeDeps.dependenciesWithUnknownVersions;
+  }
+  if (packageReferenceDeps.dependenciesWithInjectedPropVersion) {
+    depTree.dependenciesWithInjectedPropVersion =
+      packageReferenceDeps.dependenciesWithInjectedPropVersion;
   }
 
   return depTree;
@@ -177,14 +205,16 @@ export async function getDependencyTreeFromProjectFile(
 export async function getDependenciesFromPackageReference(
   manifestFile,
   includeDev: boolean = false,
-  propsMap: PropsLookup):
-  Promise <DependenciesDiscoveryResult> {
+  propsMap: PropsLookup,
+): Promise<DependenciesDiscoveryResult> {
   let dependenciesResult: DependenciesDiscoveryResult = {
     dependencies: {},
     hasDevDependencies: false,
   };
-  const packageGroups = (manifestFile?.Project?.ItemGroup ?? [])
-    .filter((itemGroup) => typeof itemGroup === 'object' && 'PackageReference' in itemGroup);
+  const packageGroups = (manifestFile?.Project?.ItemGroup ?? []).filter(
+    (itemGroup) =>
+      typeof itemGroup === 'object' && 'PackageReference' in itemGroup,
+  );
 
   if (!packageGroups.length) {
     return dependenciesResult;
@@ -192,7 +222,12 @@ export async function getDependenciesFromPackageReference(
 
   for (const packageList of packageGroups) {
     dependenciesResult = processItemGroupForPackageReference(
-      packageList, manifestFile, includeDev, dependenciesResult, propsMap);
+      packageList,
+      manifestFile,
+      includeDev,
+      dependenciesResult,
+      propsMap,
+    );
   }
 
   return dependenciesResult;
@@ -203,9 +238,12 @@ function processItemGroupForPackageReference(
   manifestFile,
   includeDev: boolean,
   dependenciesResult,
-  propsMap: PropsLookup) {
-  const targetFrameworks: string[] = packageList?.$?.Condition ?? false ?
-    getConditionalFrameworks(packageList.$.Condition) : [];
+  propsMap: PropsLookup,
+) {
+  const targetFrameworks: string[] =
+    packageList?.$?.Condition ?? false
+      ? getConditionalFrameworks(packageList.$.Condition)
+      : [];
 
   for (const dep of packageList.PackageReference) {
     const depName = dep.$.Include;
@@ -214,15 +252,26 @@ function processItemGroupForPackageReference(
       continue;
     }
     const isDev = !!dep.$.developmentDependency;
-    dependenciesResult.hasDevDependencies = dependenciesResult.hasDevDependencies || isDev;
+    dependenciesResult.hasDevDependencies =
+      dependenciesResult.hasDevDependencies || isDev;
     if (isDev && !includeDev) {
       continue;
     }
     const subDep = buildSubTreeFromPackageReference(
-      dep, isDev, manifestFile, targetFrameworks, propsMap);
-    if ((subDep as DependencyWithoutVersion).withoutVersion)  {
-      dependenciesResult.dependenciesWithUnknownVersions = dependenciesResult.dependenciesWithUnknownVersions || [];
+      dep,
+      isDev,
+      manifestFile,
+      targetFrameworks,
+      propsMap,
+    );
+    if ((subDep as DependencyUnresolvedVersion).unknownVersion) {
+      dependenciesResult.dependenciesWithUnknownVersions =
+        dependenciesResult.dependenciesWithUnknownVersions || [];
       dependenciesResult.dependenciesWithUnknownVersions.push(subDep.name);
+    } else if ((subDep as DependencyUnresolvedVersion).injectedVersion) {
+      dependenciesResult.dependenciesWithInjectedPropVersion =
+        dependenciesResult.dependenciesWithInjectedPropVersion || [];
+      dependenciesResult.dependenciesWithInjectedPropVersion.push(subDep.name);
     } else {
       dependenciesResult.dependencies[depName] = subDep as PkgTree;
     }
@@ -233,33 +282,45 @@ function processItemGroupForPackageReference(
 
 // TODO: almost same as getDependenciesFromPackageReference
 export async function getDependenciesFromReferenceInclude(
-  manifestFile, includeDev: boolean = false, propsMap: PropsLookup):
-  Promise <DependenciesDiscoveryResult> {
-
+  manifestFile,
+  includeDev: boolean = false,
+  propsMap: PropsLookup,
+): Promise<DependenciesDiscoveryResult> {
   let referenceIncludeResult: DependenciesDiscoveryResult = {
     dependencies: {},
     hasDevDependencies: false,
   };
 
-  const referenceIncludeList =
-  (manifestFile?.Project?.ItemGroup ?? [])
-  .find((itemGroup) => typeof itemGroup === 'object' && 'Reference' in itemGroup);
+  const referenceIncludeList = (manifestFile?.Project?.ItemGroup ?? []).find(
+    (itemGroup) => typeof itemGroup === 'object' && 'Reference' in itemGroup,
+  );
 
   if (!referenceIncludeList) {
     return referenceIncludeResult;
   }
 
-  referenceIncludeResult =
-      processItemGroupForReferenceInclude(
-        referenceIncludeList, manifestFile, includeDev, referenceIncludeResult, propsMap);
+  referenceIncludeResult = processItemGroupForReferenceInclude(
+    referenceIncludeList,
+    manifestFile,
+    includeDev,
+    referenceIncludeResult,
+    propsMap,
+  );
 
   return referenceIncludeResult;
 }
 
 function processItemGroupForReferenceInclude(
-  packageList, manifestFile,  includeDev, dependenciesResult, propsMap) {
-  const targetFrameworks: string[] = packageList?.$?.Condition ?? false ?
-    getConditionalFrameworks(packageList.$.Condition) : [];
+  packageList,
+  manifestFile,
+  includeDev,
+  dependenciesResult,
+  propsMap,
+) {
+  const targetFrameworks: string[] =
+    packageList?.$?.Condition ?? false
+      ? getConditionalFrameworks(packageList.$.Condition)
+      : [];
 
   for (const item of packageList.Reference) {
     const propertiesList = item.$.Include.split(',').map((i) => i.trim());
@@ -273,7 +334,8 @@ function processItemGroupForReferenceInclude(
     // TODO: identify dev deps @lili
     const isDev = false;
 
-    dependenciesResult.hasDevDependencies = dependenciesResult.hasDevDependencies || isDev;
+    dependenciesResult.hasDevDependencies =
+      dependenciesResult.hasDevDependencies || isDev;
     if (isDev && !includeDev) {
       continue;
     }
@@ -284,9 +346,15 @@ function processItemGroupForReferenceInclude(
     }
     depInfo.name = depName;
     const subDep = buildSubTreeFromReferenceInclude(
-      depInfo, isDev, manifestFile, targetFrameworks, propsMap);
-    if ((subDep as DependencyWithoutVersion).withoutVersion)  {
-      dependenciesResult.dependenciesWithUnknownVersions = dependenciesResult.dependenciesWithUnknownVersions || [];
+      depInfo,
+      isDev,
+      manifestFile,
+      targetFrameworks,
+      propsMap,
+    );
+    if ((subDep as DependencyUnresolvedVersion).unknownVersion) {
+      dependenciesResult.dependenciesWithUnknownVersions =
+        dependenciesResult.dependenciesWithUnknownVersions || [];
       dependenciesResult.dependenciesWithUnknownVersions.push(subDep.name);
     } else {
       dependenciesResult.dependencies[depName] = subDep as PkgTree;
@@ -294,12 +362,15 @@ function processItemGroupForReferenceInclude(
   }
 
   return dependenciesResult;
-
 }
 
 function buildSubTreeFromReferenceInclude(
-  dep, isDev: boolean, manifestFile, targetFrameworks: string[], propsMap: PropsLookup):
-  PkgTree | DependencyWithoutVersion {
+  dep,
+  isDev: boolean,
+  manifestFile,
+  targetFrameworks: string[],
+  propsMap: PropsLookup,
+): PkgTree | DependencyUnresolvedVersion {
   const version = extractDependencyVersion(dep, manifestFile, propsMap) || '';
   if (!_isEmpty(version)) {
     const depSubTree: PkgTree = {
@@ -315,7 +386,7 @@ function buildSubTreeFromReferenceInclude(
 
     return depSubTree;
   } else {
-    return {name: dep.name, withoutVersion: true};
+    return { name: dep.name, unknownVersion: true, injectedVersion: true };
   }
 }
 
@@ -324,12 +395,12 @@ function buildSubTreeFromPackageReference(
   isDev: boolean,
   manifestFile,
   targetFrameworks: string[],
-  propsMap: PropsLookup):
-  PkgTree | DependencyWithoutVersion {
-
+  propsMap: PropsLookup,
+): PkgTree | DependencyUnresolvedVersion {
   const version = extractDependencyVersion(dep, manifestFile, propsMap) || '';
+  const doesVersionComeFromBuildProp =
+    isDependencyVersionInjectedAsBuildProp(dep);
   if (!_isEmpty(version)) {
-
     const depSubTree: PkgTree = {
       depType: isDev ? DepType.dev : DepType.prod,
       dependencies: {},
@@ -343,24 +414,46 @@ function buildSubTreeFromPackageReference(
     }
 
     return depSubTree;
-  } else {
-    return {name: dep.$.Include, withoutVersion: true};
+  } else if (doesVersionComeFromBuildProp) {
+    return {
+      name: dep.$.Include,
+      unknownVersion: false,
+      injectedVersion: true,
+    };
   }
+
+  return { name: dep.$.Include, unknownVersion: true, injectedVersion: false };
+}
+
+function isDependencyVersionInjectedAsBuildProp(dep) {
+  const VARS_MATCHER = /^\$\((.*?)\)/;
+  let version = dep?.$?.Version || dep?.Version;
+
+  if (Array.isArray(version)) {
+    version = version[0];
+  }
+
+  const variableVersion = version && version.match(VARS_MATCHER);
+
+  return Boolean(variableVersion);
 }
 
 function extractDependencyVersion(dep, manifestFile, propsMap): string | null {
   const VARS_MATCHER = /^\$\((.*?)\)/;
-  let version  = dep?.$?.Version || dep?.Version;
+  let version = dep?.$?.Version || dep?.Version;
+
   if (Array.isArray(version)) {
     version = version[0];
   }
   const variableVersion = version && version.match(VARS_MATCHER);
+
   if (!variableVersion) {
     return version;
   }
   // version is a variable, extract it from manifest or props lookup
   const propertyName = variableVersion[1];
-  const propertyMap = {...propsMap, ...getPropertiesMap(manifestFile)};
+  const propertyMap = { ...propsMap, ...getPropertiesMap(manifestFile) };
+
   return propertyMap?.[propertyName] ?? null;
 }
 
@@ -377,10 +470,11 @@ function getConditionalFrameworks(condition: string) {
   return frameworks;
 }
 
-export async function parseXmlFile(manifestFileContents: string): Promise<object> {
+export async function parseXmlFile(
+  manifestFileContents: string,
+): Promise<object> {
   return new Promise((resolve, reject) => {
-    parseXML
-    .parseString(manifestFileContents, (err, result) => {
+    parseXML.parseString(manifestFileContents, (err, result) => {
       if (err) {
         const e = new InvalidUserInputError('xml file parsing failed');
         return reject(e);
@@ -413,15 +507,17 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   let targetFrameworksResult: string[] = [];
   const projectPropertyGroup = manifestFile?.Project?.PropertyGroup ?? [];
 
-  if (!projectPropertyGroup ) {
+  if (!projectPropertyGroup) {
     return targetFrameworksResult;
   }
-  const propertyList = projectPropertyGroup
-    .find((propertyGroup) => {
-        return 'TargetFramework' in propertyGroup
-        || 'TargetFrameworks' in propertyGroup
-        || 'TargetFrameworkVersion' in propertyGroup;
-      }) || {};
+  const propertyList =
+    projectPropertyGroup.find((propertyGroup) => {
+      return (
+        'TargetFramework' in propertyGroup ||
+        'TargetFrameworks' in propertyGroup ||
+        'TargetFrameworkVersion' in propertyGroup
+      );
+    }) || {};
 
   if (_isEmpty(propertyList)) {
     return targetFrameworksResult;
@@ -429,18 +525,26 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   // TargetFrameworks is expected to be a list ; separated
   if (propertyList.TargetFrameworks) {
     for (const item of propertyList.TargetFrameworks) {
-      targetFrameworksResult = [...targetFrameworksResult, ...getTargetFrameworks(item)];
+      targetFrameworksResult = [
+        ...targetFrameworksResult,
+        ...getTargetFrameworks(item),
+      ];
     }
   }
   // TargetFrameworkVersion is expected to be a string containing only one item
   // TargetFrameworkVersion also implies .NETFramework, for convenience
   // return longer version
   if (propertyList.TargetFrameworkVersion) {
-    targetFrameworksResult.push(`.NETFramework,Version=${propertyList.TargetFrameworkVersion[0]}`);
+    targetFrameworksResult.push(
+      `.NETFramework,Version=${propertyList.TargetFrameworkVersion[0]}`,
+    );
   }
   // TargetFrameworks is expected to be a string
   if (propertyList.TargetFramework) {
-    targetFrameworksResult = [...targetFrameworksResult, ...propertyList.TargetFramework];
+    targetFrameworksResult = [
+      ...targetFrameworksResult,
+      ...propertyList.TargetFramework,
+    ];
   }
 
   return _uniq(targetFrameworksResult);

--- a/test/fixtures/injected-prop-package-reference-version/project.csproj
+++ b/test/fixtures/injected-prop-package-reference-version/project.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCoreAppRuntimeFrameworkVersion)"/>
+    <PackageReference Include="MySql.Data" Version="8.0.12" />
+  </ItemGroup>
+
+</Project>

--- a/test/fixtures/missing-package-reference-version/project.csproj
+++ b/test/fixtures/missing-package-reference-version/project.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="MySql.Data" Version="8.0.12" />
+  </ItemGroup>
+
+</Project>

--- a/test/lib/build-dep-tree-from-project-file.spec.ts
+++ b/test/lib/build-dep-tree-from-project-file.spec.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'fs';
+import { buildDepTreeFromProjectFile } from '../../lib';
+
+describe('manifest contains <PackageReference> tag without a Version element', () => {
+  it('should return such package in dependenciesWithUnknownVersions', async () => {
+    const manifestPath = `${__dirname}/../fixtures/missing-package-reference-version/project.csproj`;
+    const manifestFileContents = readFileSync(manifestPath, 'utf-8');
+
+    const depTree = await buildDepTreeFromProjectFile(
+      manifestFileContents,
+      false,
+    );
+
+    expect(depTree).toEqual({
+      dependencies: {
+        log4net: {
+          depType: 'prod',
+          dependencies: {},
+          name: 'log4net',
+          version: '2.0.8',
+        },
+        'MySql.Data': {
+          depType: 'prod',
+          dependencies: {},
+          name: 'MySql.Data',
+          version: '8.0.12',
+        },
+      },
+      dependenciesWithUnknownVersions: ['Microsoft.AspNetCore.App'],
+      hasDevDependencies: false,
+      name: '',
+      version: '',
+    });
+  });
+});
+
+describe('manifest contains <PackageReference> tag with version injected via build property', () => {
+  it('should return such package in dependenciesWithInjectedPropVersion', async () => {
+    const manifestPath = `${__dirname}/../fixtures/injected-prop-package-reference-version/project.csproj`;
+    const manifestFileContents = readFileSync(manifestPath, 'utf-8');
+
+    const depTree = await buildDepTreeFromProjectFile(
+      manifestFileContents,
+      false,
+    );
+
+    expect(depTree).toEqual({
+      dependencies: {
+        log4net: {
+          depType: 'prod',
+          dependencies: {},
+          name: 'log4net',
+          version: '2.0.8',
+        },
+        'MySql.Data': {
+          depType: 'prod',
+          dependencies: {},
+          name: 'MySql.Data',
+          version: '8.0.12',
+        },
+      },
+      dependenciesWithInjectedPropVersion: ['Microsoft.AspNetCore.App'],
+      hasDevDependencies: false,
+      name: '',
+      version: '',
+    });
+  });
+});

--- a/test/lib/variables.test.ts
+++ b/test/lib/variables.test.ts
@@ -11,8 +11,8 @@ test('.Net C# project with variable is parsed', async (t) => {
   const manifestFileContents = fs.readFileSync(`${__dirname}/../fixtures/dotnet-variables/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj`, 'utf-8');
   const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
   t.ok(depTree);
-  t.ok(depTree.dependenciesWithUnknownVersions);
-  t.equal(depTree.dependenciesWithUnknownVersions!.length, 4);
+  t.ok(depTree.dependenciesWithInjectedPropVersion);
+  t.equal(depTree.dependenciesWithInjectedPropVersion!.length, 4);
 });
 
 test('.Net C# project with variables is parsed fully when props are read too', async (t) => {


### PR DESCRIPTION
Resolve uniquely package versions that do not contain version and package versions that are injected via build variable (prop). This is useful to guess missing version and not guess version when it's injected dynamically in SCM.

For example if we have a `PackageReference` with missing version:
```
<PackageReference Include="Microsoft.AspNetCore.App">
```

we will keep storing such packages in `dependenciesWithUnknownVersions` array in return value.

However, if we have a `PackageReference` with Version that is injected via some build property
```
<PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCoreAppRuntimeFrameworkVersion)">
```
we will return such package in `dependenciesWithInjectedPropVersion` array in return value.

This distinction is useful, because we might want to guess a version for packages in `dependenciesWithUnknownVersions` array, for example if their version can be inferred from target framework (applicable for metapackages), however, we never want to guess a version for packages in `dependenciesWithInjectedPropVersion` because these versions are already specified but in file that we might not read.
