### PR TITLE
feat: remove support for reference assemblies

### DIFF
--- a/test/fixtures/dotnet-conditional-frameworks/expected-tree.json
+++ b/test/fixtures/dotnet-conditional-frameworks/expected-tree.json
@@ -1,32 +1,21 @@
 {
-   "dependencies": {
-      "System.Reflection": {
-         "depType": "prod",
-         "dependencies": {},
-         "name": "System.Reflection",
-         "version": "4.3.0",
-         "targetFrameworks": [
-            "netstandard1.3",
-            "netstandard2.0"
-         ]
-      },
-      "System.Reflection.TypeExtensions": {
-         "depType": "prod",
-         "dependencies": {},
-         "name": "System.Reflection.TypeExtensions",
-         "version": "4.3.0",
-         "targetFrameworks": [
-            "netstandard1.3",
-            "netstandard2.0"
-         ]
-      }
-   },
-   "dependenciesWithUnknownVersions": [
-      "Microsoft.CSharp",
-      "System.Web.DynamicData",
-      "System.Web.Entity"
-   ],
-   "hasDevDependencies": false,
-   "name": "LiteDB",
-   "version": ""
+  "dependencies": {
+    "System.Reflection": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Reflection",
+      "version": "4.3.0",
+      "targetFrameworks": ["netstandard1.3", "netstandard2.0"]
+    },
+    "System.Reflection.TypeExtensions": {
+      "depType": "prod",
+      "dependencies": {},
+      "name": "System.Reflection.TypeExtensions",
+      "version": "4.3.0",
+      "targetFrameworks": ["netstandard1.3", "netstandard2.0"]
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "LiteDB",
+  "version": ""
 }

--- a/test/fixtures/dotnet-core-simple-project/expected-tree.json
+++ b/test/fixtures/dotnet-core-simple-project/expected-tree.json
@@ -83,41 +83,8 @@
       "dependencies": {},
       "name": "newtonsoft.json",
       "version": "11.0.2"
-    },
-    "System.Console": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "System.Console",
-      "version": "4.0.0.0"
-    },
-    "Newtonsoft.Json": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "Newtonsoft.Json",
-      "version": "10.0.0.0"
-    },
-    "nunit.framework": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "nunit.framework",
-      "version": "3.8.1.0"
-    },
-    "Orleans": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "Orleans",
-      "version": "1.4.0.0"
     }
   },
-  "dependenciesWithUnknownVersions": [
-    "Microsoft.CSharp",
-    "System.Web.DynamicData",
-    "System.Web.Entity",
-    "System.Web.ApplicationServices",
-    "System.ComponentModel.DataAnnotations",
-    "System",
-    "Microsoft.Web.Infrastructure"
-  ],
   "hasDevDependencies": false,
   "name": "Simple-Project-Name",
   "version": ""

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj-without-dev.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj-without-dev.json
@@ -5,24 +5,8 @@
       "dependencies": {},
       "name": "NLog",
       "version": "4.3.10"
-    },
-    "nunit.framework": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "nunit.framework",
-      "version": "3.8.1.0"
-    },
-    "Orleans": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "Orleans",
-      "version": "1.4.0.0"
     }
   },
-  "dependenciesWithUnknownVersions": [
-    "System.Web.Entity",
-    "System.Web.ApplicationServices"
-  ],
   "hasDevDependencies": true,
   "name": "simple-project-with-dev",
   "version": ""

--- a/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj.json
+++ b/test/fixtures/dotnet-simple-project-with-devDeps/expected-tree-from-csproj.json
@@ -11,24 +11,8 @@
       "dependencies": {},
       "name": "NLog",
       "version": "4.3.10"
-    },
-    "nunit.framework": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "nunit.framework",
-      "version": "3.8.1.0"
-    },
-    "Orleans": {
-      "depType": "prod",
-      "dependencies": {},
-      "name": "Orleans",
-      "version": "1.4.0.0"
     }
   },
-  "dependenciesWithUnknownVersions": [
-    "System.Web.Entity",
-    "System.Web.ApplicationServices"
-  ],
   "hasDevDependencies": true,
   "name": "simple-project-with-dev",
   "version": ""

--- a/test/fixtures/dotnet-vb-simple-project/expected-tree.json
+++ b/test/fixtures/dotnet-vb-simple-project/expected-tree.json
@@ -13,24 +13,6 @@
       "version": "11.0.2"
     }
   },
-  "dependenciesWithUnknownVersions": [
-    "System",
-    "System.Data",
-    "System.Drawing",
-    "System.Core",
-    "System.Data.DataSetExtensions",
-    "System.Web.Extensions",
-    "System.Xml.Linq",
-    "System.Web.DynamicData",
-    "System.Web.Entity",
-    "System.Web.ApplicationServices",
-    "System.ComponentModel.DataAnnotations",
-    "System.Web",
-    "System.Xml",
-    "System.Configuration",
-    "System.Web.Services",
-    "System.EnterpriseServices"
-  ],
   "hasDevDependencies": false,
   "name": "SnykTestVB",
   "version": ""

--- a/test/fixtures/reference-assemblies-with-package-reference/project.csproj
+++ b/test/fixtures/reference-assemblies-with-package-reference/project.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AssemblyName>InfoCaster.Umbraco.UrlTracker</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="businesslogic">
+      <HintPath>lib\businesslogic.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ClientDependency.Core, Version=1.7.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>lib\ClientDependency.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="MySql.Data" Version="8.0.12" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/reference-assemblies/project.csproj
+++ b/test/fixtures/reference-assemblies/project.csproj
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F8933DA-AAA2-4481-A3B3-81A58AA64FF7}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>InfoCaster.Umbraco.UrlTracker</RootNamespace>
+    <AssemblyName>InfoCaster.Umbraco.UrlTracker</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <TargetFrameworkProfile />
+    <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
+    <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="businesslogic">
+      <HintPath>lib\businesslogic.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ClientDependency.Core, Version=1.7.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>lib\ClientDependency.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="cms">
+      <HintPath>lib\cms.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="controls">
+      <HintPath>lib\controls.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="interfaces">
+      <HintPath>lib\interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>lib\log4net.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
+    <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>lib\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Activation" />
+    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\Program Files (x86)\Microsoft ASP.NET\ASP.NET MVC 4\Assemblies\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="umbraco">
+      <HintPath>lib\umbraco.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Umbraco.Core">
+      <HintPath>lib\Umbraco.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="umbraco.DataLayer">
+      <HintPath>lib\umbraco.DataLayer.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/test/lib/buildDepTreeFromProjectFile.spec.ts
+++ b/test/lib/buildDepTreeFromProjectFile.spec.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+import { buildDepTreeFromProjectFile } from '../../lib';
+
+describe('buildDepTreeFromProjectFile', () => {
+  describe('project file contains only reference assemblies', () => {
+    it('should not consider reference assemblies as dependencies', async () => {
+      const manifestFileContents = readFileSync(
+        `${__dirname}/../fixtures/reference-assemblies/project.csproj`,
+        'utf8',
+      );
+
+      const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
+
+      expect(depTree).toEqual({
+        dependencies: {},
+        hasDevDependencies: false,
+        name: 'InfoCaster.Umbraco.UrlTracker',
+        version: '',
+      });
+    });
+  });
+
+  describe('project file contains reference assemlies and PackageRefernce', () => {
+    it('should consider only PackageReference for its dependencies', async () => {
+      const manifestFileContents = readFileSync(
+        `${__dirname}/../fixtures/reference-assemblies-with-package-reference/project.csproj`,
+        'utf8',
+      );
+
+      const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
+
+      expect(depTree).toEqual({
+        dependencies: {
+          'MySql.Data': {
+            depType: 'prod',
+            dependencies: {},
+            name: 'MySql.Data',
+            version: '8.0.12',
+          },
+          log4net: {
+            depType: 'prod',
+            dependencies: {},
+            name: 'log4net',
+            version: '2.0.8',
+          },
+        },
+        hasDevDependencies: false,
+        name: 'InfoCaster.Umbraco.UrlTracker',
+        version: '',
+      });
+    });
+  });
+});

--- a/test/lib/dependencies.test.ts
+++ b/test/lib/dependencies.test.ts
@@ -16,11 +16,6 @@ test('.Net Visual Basic project tree generated as expected', async (t) => {
     false,
   );
   const expectedTree = load('dotnet-vb-simple-project/expected-tree.json');
-  t.deepEqual(
-    tree.dependenciesWithUnknownVersions!.length,
-    16,
-    'skipped empty versions',
-  );
   t.deepEqual(tree, expectedTree, 'trees are equal');
 });
 
@@ -455,39 +450,5 @@ test('.Net oldstyle project with variable is parsed and unknown skipped', async 
   const depTree = await buildDepTreeFromProjectFile(manifestFileContents);
 
   t.ok(depTree);
-  t.equal(
-    depTree.dependenciesWithUnknownVersions!.length,
-    7,
-    '7 deps with no versions specified',
-  );
-  t.deepEqual(
-    depTree.dependencies,
-    {
-      'Newtonsoft.Json': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'Newtonsoft.Json',
-        version: '10.0.0.0',
-      },
-      Orleans: {
-        depType: 'prod',
-        dependencies: {},
-        name: 'Orleans',
-        version: '1.4.0.0',
-      },
-      'System.Console': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'System.Console',
-        version: '4.0.0.0',
-      },
-      'nunit.framework': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'nunit.framework',
-        version: '3.8.1.0',
-      },
-    },
-    'deps resolved',
-  );
+  t.deepEqual(depTree.dependencies, {}, 'deps resolved');
 });

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -5,11 +5,6 @@ describe('Tests for property group tag', () => {
 
   it('should not fail when there is an property group tag', async () => {
     jest
-      .spyOn(parsers, 'getDependenciesFromReferenceInclude')
-      .mockImplementation(() =>
-        Promise.resolve({ dependencies: {}, hasDevDependencies: false }),
-      );
-    jest
       .spyOn(parsers, 'getDependenciesFromPackageReference')
       .mockImplementation(() =>
         Promise.resolve({
@@ -51,11 +46,6 @@ describe('Tests for property group tag', () => {
   });
 
   it('should not fail when there is not an empty property group tag ', async () => {
-    jest
-      .spyOn(parsers, 'getDependenciesFromReferenceInclude')
-      .mockImplementation(() =>
-        Promise.resolve({ dependencies: {}, hasDevDependencies: false }),
-      );
     jest
       .spyOn(parsers, 'getDependenciesFromPackageReference')
       .mockImplementation(() =>

--- a/test/lib/variables.test.ts
+++ b/test/lib/variables.test.ts
@@ -85,39 +85,5 @@ test('.Net oldstyle project with variable is parsed and versions resolved', asyn
   );
 
   t.ok(depTree);
-  t.equal(
-    depTree.dependenciesWithUnknownVersions!.length,
-    7,
-    '7 deps with no versions specified',
-  );
-  t.deepEqual(
-    depTree.dependencies,
-    {
-      'Newtonsoft.Json': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'Newtonsoft.Json',
-        version: '10.0.0.0',
-      },
-      Orleans: {
-        depType: 'prod',
-        dependencies: {},
-        name: 'Orleans',
-        version: '1.4.0.0',
-      },
-      'System.Console': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'System.Console',
-        version: '4.0.0.0',
-      },
-      'nunit.framework': {
-        depType: 'prod',
-        dependencies: {},
-        name: 'nunit.framework',
-        version: '3.8.1.0',
-      },
-    },
-    'deps resolved',
-  );
+  t.deepEqual(depTree.dependencies, {}, 'deps resolved');
 });


### PR DESCRIPTION
Drop support for [reference assemblies](https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies) in dependency tree creation for project files. Reference assemblies are sourced from local machine (such as local `dll` or SDK) and are not downloaded from remote feeds (such as nuget.org). Therefore we cannot provide any level of advice how to fix these packages should they be vulnerable. We also decided not to report such packages altogehter
