### PR TITLE
feat: trigger release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 jobs:
   include:
     - stage: npm release
-      node_js: '10'
+      node_js: '14.17'
       script: skip
       after_success:
         - npx semantic-release


### PR DESCRIPTION
Latest semantic-releases were failing due to outdated node version, see https://app.travis-ci.com/github/snyk/dotnet-deps-parser/jobs/549309091.
![Screenshot from 2021-11-23 12-37-52](https://user-images.githubusercontent.com/44169561/143025269-c223c929-159c-4c43-90ea-a6270619dc1b.png)

Apply minimum required node version for releases

