### PR TITLE
fix: remove the usage of _set

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,6 +1,5 @@
 import * as parseXML from 'xml2js';
 import * as _isEmpty from 'lodash.isempty';
-import * as _set from 'lodash.set';
 import * as _uniq from 'lodash.uniq';
 import { InvalidUserInputError } from '../errors';
 
@@ -339,7 +338,9 @@ export function getPropertiesMap(propsContents: any): PropsLookup {
 
   for (const group of projectPropertyGroup) {
     for (const key of Object.keys(group)) {
-      _set(props, key, group[key][0]);
+      if (group[key] && group[key][0]) {
+        group[key][0] = props;
+      }
     }
   }
   return props;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
     "lodash.isempty": "^4.4.0",
-    "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.10.0",


### PR DESCRIPTION
### Why?

- We have 1 vulnerability with `_set`, and it looks like we can avoid using `lodash.set`.