### PR TITLE
feat: [OSM-529] updated errors to be error-catalog style

### DIFF
--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,1 +1,0 @@
-export { InvalidUserInputError } from './invalid-user-input-error';

--- a/lib/errors/invalid-user-input-error.ts
+++ b/lib/errors/invalid-user-input-error.ts
@@ -1,9 +1,0 @@
-export class InvalidUserInputError extends Error {
-  public code = 422;
-  public name = 'InvalidUserInputError';
-
-  constructor(...args) {
-    super(...args);
-    Error.captureStackTrace(this, InvalidUserInputError);
-  }
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
 
 import {
   PkgTree,
@@ -22,7 +23,6 @@ import {
   getDependencyTreeFromProjectAssetsJson,
   ProjectAssetsJsonManifest,
 } from './parsers/project-assets-json-parser';
-import { InvalidUserInputError } from './errors';
 
 const PROJ_FILE_EXTENSIONS = ['.csproj', '.vbproj', '.fsproj'];
 
@@ -60,7 +60,9 @@ function buildDepTreeFromProjectAssetsJson(
   targetFramework?: string,
 ): PkgTree {
   if (!targetFramework) {
-    throw new Error('Missing targetFramework for project.assets.json');
+    throw new OpenSourceEcosystems.MissingPayloadError(
+      'Missing targetFramework for project.assets.json',
+    );
   }
   // trimming required to address files with UTF-8 with BOM encoding
   const manifestFile: ProjectAssetsJsonManifest = JSON.parse(
@@ -93,13 +95,15 @@ function buildDepTreeFromFiles(
   targetFramework?: string,
 ) {
   if (!root || !manifestFilePath) {
-    throw new Error('Missing required parameters for buildDepTreeFromFiles()');
+    throw new OpenSourceEcosystems.MissingPayloadError(
+      'Missing required parameters for building dependency tree from files',
+    );
   }
 
   const manifestFileFullPath = path.resolve(root, manifestFilePath);
 
   if (!fs.existsSync(manifestFileFullPath)) {
-    throw new Error(
+    throw new OpenSourceEcosystems.CannotGetFileFromSourceError(
       'No packages.config, project.json or project file found at ' +
         `location: ${manifestFileFullPath}`,
     );
@@ -120,7 +124,7 @@ function buildDepTreeFromFiles(
       targetFramework,
     );
   } else {
-    throw new Error(
+    throw new OpenSourceEcosystems.UnsupportedManifestFileError(
       `Unsupported file ${manifestFilePath}, Please provide ` +
         'either packages.config or project file.',
     );
@@ -133,14 +137,14 @@ function extractTargetFrameworksFromFiles(
   includeDev = false,
 ) {
   if (!root || !manifestFilePath) {
-    throw new Error(
+    throw new OpenSourceEcosystems.MissingPayloadError(
       'Missing required parameters for extractTargetFrameworksFromFiles()',
     );
   }
 
   const manifestFileFullPath = path.resolve(root, manifestFilePath);
   if (!fs.existsSync(manifestFileFullPath)) {
-    throw new Error(
+    throw new OpenSourceEcosystems.CannotGetFileFromSourceError(
       'No project file found at ' + `location: ${manifestFileFullPath}`,
     );
   }
@@ -157,7 +161,7 @@ function extractTargetFrameworksFromFiles(
   } else if (manifestFilePath.endsWith('project.assets.json')) {
     return extractTargetFrameworksFromProjectAssetsJson(manifestFileContents);
   } else {
-    throw new Error(
+    throw new OpenSourceEcosystems.UnsupportedManifestFileError(
       `Unsupported file ${manifestFilePath}, Please provide ` +
         'a project *.csproj, *.vbproj, *.fsproj or packages.config file.',
     );
@@ -167,27 +171,15 @@ function extractTargetFrameworksFromFiles(
 async function extractTargetFrameworksFromProjectFile(
   manifestFileContents: string,
 ): Promise<string[]> {
-  try {
-    const manifestFile: object = await parseXmlFile(manifestFileContents);
-    return getTargetFrameworksFromProjectFile(manifestFile);
-  } catch (err: any) {
-    throw new Error(
-      `Extracting target framework failed with error ${err.message}`,
-    );
-  }
+  const manifestFile: object = await parseXmlFile(manifestFileContents);
+  return getTargetFrameworksFromProjectFile(manifestFile);
 }
 
 async function extractTargetFrameworksFromProjectConfig(
   manifestFileContents: string,
 ): Promise<string[]> {
-  try {
-    const manifestFile: object = await parseXmlFile(manifestFileContents);
-    return getTargetFrameworksFromProjectConfig(manifestFile);
-  } catch (err: any) {
-    throw new Error(
-      `Extracting target framework failed with error ${err.message}`,
-    );
-  }
+  const manifestFile: object = await parseXmlFile(manifestFileContents);
+  return getTargetFrameworksFromProjectConfig(manifestFile);
 }
 
 async function containsPackageReference(manifestFileContents: string) {
@@ -205,43 +197,38 @@ async function containsPackageReference(manifestFileContents: string) {
 async function extractTargetFrameworksFromProjectJson(
   manifestFileContents: string,
 ): Promise<string[]> {
+  let manifestFile;
   try {
     // trimming required to address files with UTF-8 with BOM encoding
-    const manifestFile = JSON.parse(manifestFileContents.trim());
-    return getTargetFrameworksFromProjectJson(manifestFile);
+    manifestFile = JSON.parse(manifestFileContents.trim());
   } catch (err: any) {
-    throw new Error(
-      `Extracting target framework failed with error ${err.message}`,
+    throw new OpenSourceEcosystems.UnparseableManifestError(
+      'Failed to parse manifest file',
     );
   }
+  return getTargetFrameworksFromProjectJson(manifestFile);
 }
 
 async function extractTargetFrameworksFromProjectAssetsJson(
   manifestFileContents: string,
 ): Promise<string[]> {
+  let manifestFile;
   try {
     // trimming required to address files with UTF-8 with BOM encoding
-    const manifestFile = JSON.parse(manifestFileContents.trim());
-    return getTargetFrameworksFromProjectAssetsJson(manifestFile);
+    manifestFile = JSON.parse(manifestFileContents.trim());
   } catch (err: any) {
-    throw new Error(
-      `Extracting target framework failed with error ${err.message}`,
+    throw new OpenSourceEcosystems.UnparseableManifestError(
+      'Failed to parse manifest file',
     );
   }
+  return getTargetFrameworksFromProjectAssetsJson(manifestFile);
 }
 
 async function extractProps(propsFileContents: string): Promise<PropsLookup> {
-  try {
-    const propsFile: object = await parseXmlFile(propsFileContents);
+  const propsFile: object = await parseXmlFile(propsFileContents);
 
-    if (!propsFile) {
-      throw new InvalidUserInputError('xml file parsing failed');
-    }
-    return getPropertiesMap(propsFile);
-  } catch (err: any) {
-    if (err.name === 'InvalidUserInputError') {
-      throw err;
-    }
-    throw new Error(`Extracting props failed with error ${err.message}`);
+  if (!propsFile) {
+    throw new OpenSourceEcosystems.MissingPayloadError('Empty xml file');
   }
+  return getPropertiesMap(propsFile);
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
-import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
 
 import {
   PkgTree,
@@ -104,8 +104,10 @@ function buildDepTreeFromFiles(
 
   if (!fs.existsSync(manifestFileFullPath)) {
     throw new OpenSourceEcosystems.CannotGetFileFromSourceError(
-      'No packages.config, project.json or project file found at ' +
-        `location: ${manifestFileFullPath}`,
+      'No packages.config, project.json or project file found',
+      {
+        location: manifestFileFullPath,
+      },
     );
   }
 
@@ -125,8 +127,11 @@ function buildDepTreeFromFiles(
     );
   } else {
     throw new OpenSourceEcosystems.UnsupportedManifestFileError(
-      `Unsupported file ${manifestFilePath}, Please provide ` +
+      'Unsupported file, please provide ' +
         'either packages.config or project file.',
+      {
+        location: manifestFilePath,
+      },
     );
   }
 }
@@ -145,7 +150,10 @@ function extractTargetFrameworksFromFiles(
   const manifestFileFullPath = path.resolve(root, manifestFilePath);
   if (!fs.existsSync(manifestFileFullPath)) {
     throw new OpenSourceEcosystems.CannotGetFileFromSourceError(
-      'No project file found at ' + `location: ${manifestFileFullPath}`,
+      'No project file found',
+      {
+        location: manifestFileFullPath,
+      },
     );
   }
 
@@ -162,8 +170,11 @@ function extractTargetFrameworksFromFiles(
     return extractTargetFrameworksFromProjectAssetsJson(manifestFileContents);
   } else {
     throw new OpenSourceEcosystems.UnsupportedManifestFileError(
-      `Unsupported file ${manifestFilePath}, Please provide ` +
+      'Unsupported file, please provide ' +
         'a project *.csproj, *.vbproj, *.fsproj or packages.config file.',
+      {
+        location: manifestFilePath,
+      },
     );
   }
 }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,6 +1,6 @@
 import * as parseXML from 'xml2js';
 import { isEmpty, set, uniq } from 'lodash';
-import { InvalidUserInputError } from '../errors';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
 
 export interface PkgTree {
   name: string;
@@ -316,7 +316,9 @@ export async function parseXmlFile(
   return new Promise((resolve, reject) => {
     parseXML.parseString(manifestFileContents, (err, result) => {
       if (err) {
-        const e = new InvalidUserInputError('xml file parsing failed');
+        const e = new OpenSourceEcosystems.UnparseableManifestError(
+          'Manifest xml file parsing failed',
+        );
         return reject(e);
       }
       return resolve(result);

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,6 +1,6 @@
 import * as parseXML from 'xml2js';
 import { isEmpty, set, uniq } from 'lodash';
-import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
 
 export interface PkgTree {
   name: string;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
+    "@snyk/error-catalog-nodejs": "^3.10.0",
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
     "tslib": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
-    "@snyk/error-catalog-nodejs": "^3.10.0",
+    "@snyk/error-catalog-nodejs-public": "^3.18.6",
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
     "tslib": "^2.5.0",

--- a/test/lib/dependencies.spec.ts
+++ b/test/lib/dependencies.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { buildDepTreeFromFiles, buildDepTreeFromProjectFile } from '../../lib';
 import { getDependencyTreeFromProjectAssetsJson } from '../../lib/parsers/project-assets-json-parser';
-import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
 
 const load = (filename) =>
   JSON.parse(fs.readFileSync(`${__dirname}/../fixtures/${filename}`, 'utf8'));

--- a/test/lib/dependencies.spec.ts
+++ b/test/lib/dependencies.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { buildDepTreeFromFiles, buildDepTreeFromProjectFile } from '../../lib';
 import { getDependencyTreeFromProjectAssetsJson } from '../../lib/parsers/project-assets-json-parser';
-import { InvalidUserInputError } from '../../lib/errors';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
 
 const load = (filename) =>
   JSON.parse(fs.readFileSync(`${__dirname}/../fixtures/${filename}`, 'utf8'));
@@ -94,9 +94,10 @@ test('.Net dotnet-empty-manifest returns empty tree', async () => {
 });
 
 test('.Net dotnet-invalid-manifest throws', async () => {
-  const invalidUserInputError = new InvalidUserInputError(
-    'xml file parsing failed',
-  );
+  const unparsableManifestError =
+    new OpenSourceEcosystems.UnparseableManifestError(
+      'Manifest xml file parsing failed',
+    );
 
   const includeDev = false;
   expect(
@@ -105,7 +106,7 @@ test('.Net dotnet-invalid-manifest throws', async () => {
       'packages.config',
       includeDev,
     ),
-  ).rejects.toStrictEqual(invalidUserInputError);
+  ).rejects.toStrictEqual(unparsableManifestError);
 });
 
 test('.Net dotnet-simple-project-with-devDeps tree generated as expected', async () => {
@@ -196,9 +197,10 @@ test('.Net .csproj dotnet-empty-manifest returns empty tree', async () => {
 });
 
 test('.Net .csproj core dotnet-invalid-manifest throws', async () => {
-  const invalidUserInputError = new InvalidUserInputError(
-    'xml file parsing failed',
-  );
+  const unparsableManifestError =
+    new OpenSourceEcosystems.UnparseableManifestError(
+      'Manifest xml file parsing failed',
+    );
 
   const includeDev = false;
   expect(
@@ -207,7 +209,7 @@ test('.Net .csproj core dotnet-invalid-manifest throws', async () => {
       'invalid.csproj',
       includeDev,
     ),
-  ).rejects.toStrictEqual(invalidUserInputError);
+  ).rejects.toStrictEqual(unparsableManifestError);
 });
 
 test('.Net dotnet-simple-project-with-devDeps with includeDev=false tree generated as expected', async () => {

--- a/test/lib/props.spec.ts
+++ b/test/lib/props.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { extractProps } from '../../lib';
-import { InvalidUserInputError } from '../../lib/errors';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
 
 test('.props file is parsed', async () => {
   const propsFileContents = fs.readFileSync(
@@ -18,10 +18,10 @@ test('.props file is parsed', async () => {
 });
 
 test('.props file is not parsed due to invalid xml', async () => {
-  const invalidUserInputError = new InvalidUserInputError(
-    'xml file parsing failed',
+  const error = new OpenSourceEcosystems.UnparseableManifestError(
+    'Manifest xml file parsing failed',
   );
-  expect(extractProps('</>')).rejects.toStrictEqual(invalidUserInputError);
+  expect(extractProps('</>')).rejects.toStrictEqual(error);
 });
 
 test('empty .props file is parsed', async () => {
@@ -29,11 +29,4 @@ test('empty .props file is parsed', async () => {
     '<?xml version="1.0" encoding="utf-8"?><Project></Project></xml>',
   );
   expect(props).toEqual({});
-});
-
-test('empty .props file is not parsed due to invalid xml', async () => {
-  const invalidUserInputError = new InvalidUserInputError(
-    'xml file parsing failed',
-  );
-  expect(extractProps('</>')).rejects.toStrictEqual(invalidUserInputError);
 });

--- a/test/lib/props.spec.ts
+++ b/test/lib/props.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { extractProps } from '../../lib';
-import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
 
 test('.props file is parsed', async () => {
   const propsFileContents = fs.readFileSync(

--- a/test/lib/target-frameworks.spec.ts
+++ b/test/lib/target-frameworks.spec.ts
@@ -208,9 +208,7 @@ describe('Target framework tests', () => {
 
       fail('Should throw an error for failing to extract the target framework');
     } catch (err: any) {
-      expect(err.message).toBe(
-        'Extracting target framework failed with error Unexpected string in JSON at position 62934',
-      );
+      expect(err.message).toBe('Unable to parse manifest file');
     }
   });
 });


### PR DESCRIPTION
#### What does this PR do?

Changed error to be from error-catalog so that they are properly handlled for dotnet-deps.

#### What are the relevant tickets?
[Jira ticket OSM-529](https://snyksec.atlassian.net/browse/OSM-529)


#### Additional questions
Should we also handle unexpected errors?
