### PR TITLE
fix: [OSM-699] Adding new `TargetFramework` guard for V2 logic

### DIFF
--- a/test/lib/target-frameworks.spec.ts
+++ b/test/lib/target-frameworks.spec.ts
@@ -1,6 +1,9 @@
 // tslint:disable:max-line-length
 // tslint:disable:object-literal-key-quotes
-import { extractTargetFrameworksFromFiles } from '../../lib';
+import {
+  extractTargetFrameworksFromFiles,
+  isSupportedByV2GraphGeneration,
+} from '../../lib';
 
 describe('Target framework tests', () => {
   it.concurrent(
@@ -210,4 +213,50 @@ describe('Target framework tests', () => {
       expect(err.message).toBe('Unable to parse manifest file');
     }
   });
+
+  it.each([
+    {
+      targetFramework: '',
+      expected: false,
+    },
+    {
+      targetFramework: 'foobar',
+      expected: false,
+    },
+    // Windows Store
+    {
+      targetFramework: 'netcore45',
+      expected: false,
+    },
+    // .NET Standard
+    {
+      targetFramework: 'netstandard1.5',
+      expected: true,
+    },
+    // .NET Core
+    {
+      targetFramework: 'netcoreapp3.1',
+      expected: true,
+    },
+    // .NET >= 5
+    {
+      targetFramework: 'net7.0',
+      expected: true,
+    },
+    // .NET Framework < 5
+    {
+      targetFramework: 'net403',
+      expected: false,
+    },
+    // .NET Framework < 5
+    {
+      targetFramework: 'net48',
+      expected: false,
+    },
+  ])(
+    'accepts or rejects specific target frameworks for runtime assembly parsing when targetFramework is: $targetFramework.original',
+    ({ targetFramework, expected }) => {
+      expect(isSupportedByV2GraphGeneration(targetFramework)).toEqual(expected);
+    },
+  );
 });


### PR DESCRIPTION
Currently the logic exists in the `snyk-nuget-plugin` code: https://github.com/snyk/snyk-nuget-plugin/blob/9c48169064bb397acfb2d7b727892fdddc70fb7c/lib/nuget-parser/runtime-assembly.ts#L24-L42

We are moving it here to share it between our internal and external services, and avoid repeating ourselves unnecessarily.

After this merge we're going to remove it from `snyk-nuget-plugin` and add it to our internal service as well.