### PR TITLE
fix: [OSM-441] Adjusting to reorganized error catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
-    "@snyk/error-catalog-nodejs-public": "^3.18.6",
+    "@snyk/error-catalog-nodejs-public": "^4.0.1",
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
     "xml2js": "0.6.2"


### PR DESCRIPTION
Updating `error-catalog` dependency due to some error catalog restructuring and adjusting changed errors accordingly.
