### PR TITLE
fix: handle-empty-property-group

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -352,14 +352,19 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   if (!projectPropertyGroup) {
     return targetFrameworksResult;
   }
-  const propertyList =
-    projectPropertyGroup.find((propertyGroup) => {
-      return (
-        'TargetFramework' in propertyGroup ||
-        'TargetFrameworks' in propertyGroup ||
-        'TargetFrameworkVersion' in propertyGroup
-      );
-    }) || {};
+  let propertyList: any = {};
+  try {
+    propertyList =
+      projectPropertyGroup.find((propertyGroup) => {
+        return (
+          'TargetFramework' in propertyGroup ||
+          'TargetFrameworks' in propertyGroup ||
+          'TargetFrameworkVersion' in propertyGroup
+        );
+      }) || {};
+  } catch (err) {
+    propertyList = {};
+  }
 
   if (isEmpty(propertyList)) {
     return targetFrameworksResult;

--- a/test/fixtures/dotnet-empty-property-group/empty-property-group.csproj
+++ b/test/fixtures/dotnet-empty-property-group/empty-property-group.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+  </PropertyGroup>
+
+</Project>

--- a/test/fixtures/dotnet-empty-property-group/expected-tree.json
+++ b/test/fixtures/dotnet-empty-property-group/expected-tree.json
@@ -1,0 +1,6 @@
+{
+  "name": "",
+  "version": "",
+  "hasDevDependencies": false,
+  "dependencies": {}
+}

--- a/test/fixtures/dotnet-empty-property-group/packages.config
+++ b/test/fixtures/dotnet-empty-property-group/packages.config
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?>

--- a/test/lib/dependencies.spec.ts
+++ b/test/lib/dependencies.spec.ts
@@ -93,6 +93,17 @@ test('.Net dotnet-empty-manifest returns empty tree', async () => {
   expect(tree).toEqual(expectedTree);
 });
 
+test('.Net dotnet-empty-property-group returns empty tree', async () => {
+  const includeDev = false;
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-empty-property-group`,
+    'packages.config',
+    includeDev,
+  );
+  const expectedTree = load('dotnet-empty-property-group/expected-tree.json');
+  expect(tree).toEqual(expectedTree);
+});
+
 test('.Net dotnet-invalid-manifest throws', async () => {
   const unparsableManifestError =
     new OpenSourceEcosystems.UnparseableManifestError(
@@ -193,6 +204,17 @@ test('.Net .csproj dotnet-empty-manifest returns empty tree', async () => {
     includeDev,
   );
   const expectedTree = load('dotnet-empty-manifest/expected-tree.json');
+  expect(tree).toEqual(expectedTree);
+});
+
+test('.Net .csproj dotnet-empty-property-group returns empty tree', async () => {
+  const includeDev = false;
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-empty-property-group`,
+    'empty-property-group.csproj',
+    includeDev,
+  );
+  const expectedTree = load('dotnet-empty-property-group/expected-tree.json');
   expect(tree).toEqual(expectedTree);
 });
 

--- a/test/lib/target-frameworks.spec.ts
+++ b/test/lib/target-frameworks.spec.ts
@@ -65,6 +65,17 @@ describe('Target framework tests', () => {
   );
 
   it.concurrent(
+    '.Net .csproj dotnet-empty-property-group target framework extracted',
+    async () => {
+      const targetFrameworks = await extractTargetFrameworksFromFiles(
+        `${__dirname}/../fixtures/dotnet-empty-property-group`,
+        'empty-property-group.csproj',
+      );
+      expect(targetFrameworks).toEqual([]);
+    },
+  );
+
+  it.concurrent(
     '.Net .csproj multiple target frameworks extracted as expected',
     async () => {
       const targetFrameworks = await extractTargetFrameworksFromFiles(
@@ -125,6 +136,17 @@ describe('Target framework tests', () => {
     async () => {
       const targetFrameworks = await extractTargetFrameworksFromFiles(
         `${__dirname}/../fixtures/dotnet-empty-manifest`,
+        'packages.config',
+      );
+      expect(targetFrameworks).toEqual([]);
+    },
+  );
+
+  it.concurrent(
+    '.Net packages.config dotnet-empty-property-group target framework extracted',
+    async () => {
+      const targetFrameworks = await extractTargetFrameworksFromFiles(
+        `${__dirname}/../fixtures/dotnet-empty-property-group`,
         'packages.config',
       );
       expect(targetFrameworks).toEqual([]);


### PR DESCRIPTION
Some users might use propertyGroups like:
```
  <PropertyGroup>
  </PropertyGroup>
```
This PR adds handling for that case, and returns the usual empty array instead of an error.