### PR TITLE
feat: [OSM-2902] Parse global.json with a JSONC parser

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
 import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
+import * as jsonc from 'jsonc-parser';
 
 import {
   DepType,
@@ -323,13 +324,9 @@ function extractTargetSdkFromGlobalJson(
   manifestFileContents: string,
 ): string | undefined {
   try {
-    // Remove /* */ comments from the JSON string (if any)
-    // It's allowed: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#comments-in-globaljson
-    const jsonWithoutComments = manifestFileContents.replace(
-      /\/\*[\s\S]*?\*\/|\/\/.*$/gm,
-      '',
-    );
-    const globalJsonAsObj = JSON.parse(jsonWithoutComments);
+    // Use a JSONC parser as that's the format of global.json, which accepts comments,
+    // see https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#comments-in-globaljson
+    const globalJsonAsObj = jsonc.parse(manifestFileContents);
     return globalJsonAsObj?.sdk?.version;
   } catch (err: any) {
     throw new Error(

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/snyk/dotnet-deps-parser#readme",
   "dependencies": {
     "@snyk/error-catalog-nodejs-public": "^4.0.1",
+    "jsonc-parser": "^3.3.1",
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
     "xml2js": "0.6.2"

--- a/test/fixtures/dotnet-core-global-json/global_with_comments.json
+++ b/test/fixtures/dotnet-core-global-json/global_with_comments.json
@@ -1,6 +1,7 @@
 {
   // This is a comment.
   "sdk": {
+    "comment": "This is a comment with a URL https://google.com",
     "version": "7.0.100" /* This is comment 2*/
     /* This is a
     multiline comment.*/


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Use an actual JSONC parser to parse global.json, as this is the format Microsoft uses, rather than trying to remove comments with a regex. I picked https://www.npmjs.com/package/jsonc-parser as this has 23M weekly downloads, and is well-maintained by Microsoft.

I originally found this issue when trying to import public repo `OrchardCore` which has this global.json:
```json
{
  "comment": "We only update the version manually with major SDK updates to keep using any more recent SDK version possible. See https://github.com/OrchardCMS/OrchardCore/pull/17808.",
  "sdk": {
    "version": "9.0.100",
    "rollForward": "latestMajor"
  }
}
```