### PR TITLE
fix: allow TF to be picked from inside When conditionals

### DIFF
--- a/test/fixtures/dotnet-directory-build-props/Directory.Build.props
+++ b/test/fixtures/dotnet-directory-build-props/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+    <PropertyGroup>
+        <ProjectArtifacts>$(MSBuildThisFileDirectory)artifacts\$(MSBuildProjectName)\</ProjectArtifacts>
+    </PropertyGroup>
+
+    <Choose>
+
+        <When Condition="'$(MSBuildProjectExtension)' == '.fsproj'">
+            <PropertyGroup>
+                <BaseIntermediateOutputPath>$(ProjectArtifacts)obj\</BaseIntermediateOutputPath>
+            </PropertyGroup>
+        </When>
+
+        <When Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+            <PropertyGroup>
+                <TargetFramework>net9.0</TargetFramework>
+            </PropertyGroup>
+        </When>
+
+    </Choose>
+</Project>

--- a/test/lib/conditional-targetframework.spec.ts
+++ b/test/lib/conditional-targetframework.spec.ts
@@ -48,4 +48,22 @@ describe('for manifest files with conditional target frameworks', () => {
       expect(regularTargetFrameworks).toEqual(conditionalTargetFrameworks);
     },
   );
+
+  it('should correctly parse TargetFramework from Directory.build.props with Choose/When conditions', async () => {
+    const directoryBuildPropsPath = path.resolve(
+      `${__dirname}/../fixtures/dotnet-directory-build-props`,
+      'Directory.Build.props',
+    );
+
+    const manifestFileContents = fs.readFileSync(
+      directoryBuildPropsPath,
+      'utf-8',
+    );
+
+    const targetFrameworks =
+      await extractTargetFrameworksFromProjectFile(manifestFileContents);
+
+    expect(targetFrameworks).toBeTruthy();
+    expect(targetFrameworks).toEqual(['net9.0']);
+  });
 });


### PR DESCRIPTION
<TargetFramework> property can be defined inside <When> conditionals, this PR adds support for that case