### PR TITLE
fix: [OSE-136] handle empty PropertyGroups in csproj files

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -338,6 +338,10 @@ export function getPropertiesMap(propsContents: any): PropsLookup {
   }
 
   for (const group of projectPropertyGroup) {
+    // Skip empty property groups that are parsed as strings
+    if (typeof group === 'string') {
+      continue;
+    }
     for (const key of Object.keys(group)) {
       set(props, key, group[key][0]);
     }
@@ -355,13 +359,15 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
   if (projectPropertyGroup) {
     try {
       propertyList =
-        projectPropertyGroup.find((propertyGroup) => {
-          return (
-            'TargetFramework' in propertyGroup ||
-            'TargetFrameworks' in propertyGroup ||
-            'TargetFrameworkVersion' in propertyGroup
-          );
-        }) || {};
+        projectPropertyGroup
+          .filter((propertyGroup) => typeof propertyGroup === 'object')
+          .find((propertyGroup) => {
+            return (
+              'TargetFramework' in propertyGroup ||
+              'TargetFrameworks' in propertyGroup ||
+              'TargetFrameworkVersion' in propertyGroup
+            );
+          }) || {};
     } catch (err) {
       propertyList = {};
     }
@@ -375,13 +381,15 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
       for (const when of whenElements) {
         const whenPropertyGroups = when.PropertyGroup ?? [];
         try {
-          const foundProperty = whenPropertyGroups.find((propertyGroup) => {
-            return (
-              'TargetFramework' in propertyGroup ||
-              'TargetFrameworks' in propertyGroup ||
-              'TargetFrameworkVersion' in propertyGroup
-            );
-          });
+          const foundProperty = whenPropertyGroups
+            .filter((propertyGroup) => typeof propertyGroup === 'object')
+            .find((propertyGroup) => {
+              return (
+                'TargetFramework' in propertyGroup ||
+                'TargetFrameworks' in propertyGroup ||
+                'TargetFrameworkVersion' in propertyGroup
+              );
+            });
           if (foundProperty && !isEmpty(foundProperty)) {
             propertyList = foundProperty;
             break;

--- a/test/fixtures/dotnet-empty-self-closing-property-group/empty-self-closing.csproj
+++ b/test/fixtures/dotnet-empty-self-closing-property-group/empty-self-closing.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup />
+  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+

--- a/test/fixtures/dotnet-empty-self-closing-property-group/expected-tree.json
+++ b/test/fixtures/dotnet-empty-self-closing-property-group/expected-tree.json
@@ -1,0 +1,7 @@
+{
+  "name": "",
+  "version": "",
+  "hasDevDependencies": false,
+  "dependencies": {}
+}
+

--- a/test/lib/dependencies.spec.ts
+++ b/test/lib/dependencies.spec.ts
@@ -218,6 +218,19 @@ test('.Net .csproj dotnet-empty-property-group returns empty tree', async () => 
   expect(tree).toEqual(expectedTree);
 });
 
+test('.Net .csproj dotnet-empty-self-closing-property-group returns empty tree', async () => {
+  const includeDev = false;
+  const tree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/dotnet-empty-self-closing-property-group`,
+    'empty-self-closing.csproj',
+    includeDev,
+  );
+  const expectedTree = load(
+    'dotnet-empty-self-closing-property-group/expected-tree.json',
+  );
+  expect(tree).toEqual(expectedTree);
+});
+
 test('.Net .csproj core dotnet-invalid-manifest throws', async () => {
   const unparsableManifestError =
     new OpenSourceEcosystems.UnparseableManifestError(

--- a/test/lib/target-frameworks.spec.ts
+++ b/test/lib/target-frameworks.spec.ts
@@ -78,6 +78,17 @@ describe('Target framework tests', () => {
   );
 
   it.concurrent(
+    '.Net .csproj dotnet-empty-self-closing-property-group target framework extracted',
+    async () => {
+      const targetFrameworks = await extractTargetFrameworksFromFiles(
+        `${__dirname}/../fixtures/dotnet-empty-self-closing-property-group`,
+        'empty-self-closing.csproj',
+      );
+      expect(targetFrameworks).toEqual(['net6.0']);
+    },
+  );
+
+  it.concurrent(
     '.Net .csproj multiple target frameworks extracted as expected',
     async () => {
       const targetFrameworks = await extractTargetFrameworksFromFiles(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dotnet-deps-parser/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes handling of empty self-closing PropertyGroups in .csproj files that were causing parsing failures with "cannot use operator 'in' for an empty string" errors.

#### Where should the reviewer start?

Review the changes in `lib/parsers/index.ts` - three functions updated to filter out string-type property groups before using the `in` operator. The pattern follows existing defensive code at lines 151-154.

#### How should this be manually tested?

Run `npm test` - all 101 tests pass including new test cases:
- `dotnet-empty-self-closing-property-group` fixture with multiple empty PropertyGroups
- Tests in `dependencies.spec.ts` and `target-frameworks.spec.ts`

#### Any background context you want to provide?

The xml2js parser converts empty self-closing tags like `<PropertyGroup />` and `<PropertyGroup></PropertyGroup>` into empty strings (`""`). When the code attempts to use the `in` operator on these strings, it throws an error. This is a common pattern in .NET projects, especially with conditional configurations.

#### What are the relevant tickets?

[OSE-136](https://snyksec.atlassian.net/browse/OSE-136)

#### Screenshots

N/A - Parser fix

#### Additional questions

None

[OSE-136]: https://snyksec.atlassian.net/browse/OSE-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ