### PR TITLE
fix: Update lodash to `v4.18.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@snyk/error-catalog-nodejs-public": "^4.0.1",
     "jsonc-parser": "^3.3.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "source-map-support": "^0.5.21",
     "xml2js": "0.6.2"
   },


### PR DESCRIPTION
### Summary

Bumps `lodash` to `v4.18.1` to address security scan issues.