### PR TITLE
fix: [OSM-3472] Adjusts `TargetFramework` extraction to trim whitespace

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -429,18 +429,19 @@ export function getTargetFrameworksFromProjectFile(manifestFile) {
     // sanity check
     if (Array.isArray(propertyList.TargetFramework)) {
       // mutate the array to effectively "ignore" conditions
-      propertyList.TargetFramework = propertyList.TargetFramework.map(
-        (framework) => {
-          if (
-            framework &&
-            typeof framework === 'object' &&
-            Object.hasOwnProperty.call(framework, '_')
-          ) {
-            return framework._;
-          }
-          return framework;
-        },
-      );
+      const frameworks = propertyList.TargetFramework.map((framework) => {
+        if (
+          framework &&
+          typeof framework === 'object' &&
+          Object.hasOwnProperty.call(framework, '_')
+        ) {
+          return framework._;
+        }
+        return framework;
+      });
+      propertyList.TargetFramework = frameworks
+        .map((x) => x.trim())
+        .filter((x) => !isEmpty(x));
     }
 
     targetFrameworksResult = [
@@ -466,7 +467,10 @@ function getTargetFrameworks(item: string | any) {
   if (typeof item === 'object' && Object.hasOwnProperty.call(item, '_')) {
     item = item._;
   }
-  return item.split(';').filter((x) => !isEmpty(x));
+  return item
+    .split(';')
+    .map((x) => x.trim())
+    .filter((x) => !isEmpty(x));
 }
 
 export function getTargetFrameworksFromProjectConfig(manifestFile) {

--- a/test/lib/target-frameworks.spec.ts
+++ b/test/lib/target-frameworks.spec.ts
@@ -1,6 +1,7 @@
 import {
   extractTargetFrameworksFromFiles,
   extractProjectSdkFromProjectFile,
+  extractTargetFrameworksFromProjectFile,
   isSupportedByV2GraphGeneration,
   isSupportedByV3GraphGeneration,
 } from '../../lib';
@@ -97,6 +98,191 @@ describe('Target framework tests', () => {
       );
 
       expect(targetFrameworks).toEqual(['netstandard2.0', 'net462']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj trims leading whitespace from target frameworks',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>netstandard2.0; net48</TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['netstandard2.0', 'net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj trims trailing whitespace from target frameworks',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>netstandard2.0 ;net48 </TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['netstandard2.0', 'net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj trims both leading and trailing whitespace from target frameworks',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks> netstandard2.0 ; net48 ; netcoreapp3.1 </TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual([
+        'netstandard2.0',
+        'net48',
+        'netcoreapp3.1',
+      ]);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj handles single target framework with whitespace',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework> net48 </TargetFramework>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj handles single target framework without whitespace (baseline)',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework>net48</TargetFramework>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj handles single target framework with extreme whitespace',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework>   net48   </TargetFramework>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj handles single target framework with tabs and newlines',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework>	
+          net48	
+          </TargetFramework>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual(['net48']);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj preserves frameworks without whitespace (baseline)',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>netstandard2.0;net48;netcoreapp3.1</TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual([
+        'netstandard2.0',
+        'net48',
+        'netcoreapp3.1',
+      ]);
+    },
+  );
+
+  it.concurrent('.Net .csproj handles extreme whitespace cases', async () => {
+    const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>   netstandard2.0   ;   net48   ;   netcoreapp3.1   </TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+    const targetFrameworks =
+      await extractTargetFrameworksFromProjectFile(manifest);
+    expect(targetFrameworks).toEqual([
+      'netstandard2.0',
+      'net48',
+      'netcoreapp3.1',
+    ]);
+  });
+
+  it.concurrent(
+    '.Net .csproj handles tabs and newlines in target frameworks',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>	netstandard2.0	;
+          net48	;	netcoreapp3.1	</TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual([
+        'netstandard2.0',
+        'net48',
+        'netcoreapp3.1',
+      ]);
+    },
+  );
+
+  it.concurrent(
+    '.Net .csproj handles empty segments from extra semicolons',
+    async () => {
+      const manifest = `<Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFrameworks>;;netstandard2.0;; net48 ;;netcoreapp3.1;;</TargetFrameworks>
+        </PropertyGroup>
+      </Project>`;
+
+      const targetFrameworks =
+        await extractTargetFrameworksFromProjectFile(manifest);
+      expect(targetFrameworks).toEqual([
+        'netstandard2.0',
+        'net48',
+        'netcoreapp3.1',
+      ]);
     },
   );
 


### PR DESCRIPTION
### Summary

We now `trim()` the `TargetFrameworks` and `TargetFramework` extracted from the project xml.

e.g.:
* `<TargetFrameworks>net6.0; net8.0</TargetFrameworks>` => `['net6.0', 'net8.0']`
* `<TargetFramework> net6.0 </TargetFramework>` => `['net6.0']`
